### PR TITLE
fix: delete `cr` eslint 에러 해결

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
     plugins: ["import", "prettier"],
     parser: "@babel/eslint-parser",
     rules: {
-        "prettier/prettier": "error",
+        "prettier/prettier": [
+            "error",
+            {
+                endOfLine: "auto"
+            }
+        ],
         "import/prefer-default-export": "off",
         "class-methods-use-this": "off",
         "no-useless-constructor": "off",


### PR DESCRIPTION
## 📕 제목

delete `cr` eslint 에러 해결

관련 이슈 #23

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] delete `cr` eslint 에러 해결


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ESLint를 설정하던 중 다음과 같은 오류 발생
![image](https://user-images.githubusercontent.com/33643752/97794932-78ccb400-1c43-11eb-90ef-b6f428b08f0e.png)
- 이 문제는 EOL에 대한 문제로 파일 변경 사항을 보시면 EOL을 auto로 바꿔주면서 해결
- 오류가 나도 실행은 되긴하지만 혹시 다른 분들 같은 오류가 뜨실까봐...! PR 보냅니다!
- 브랜치 명을 다시 설정한 후 요청드립니다.
- 프론트 ESLint에는 반영되어 있는 사항이었네요! 
- [참조](https://noogoonaa.tistory.com/62)