### PR TITLE
fix: 연관 관계 설정 수정

### DIFF
--- a/backend/src/model/comment-content.js
+++ b/backend/src/model/comment-content.js
@@ -1,0 +1,28 @@
+import { IsString } from "class-validator";
+import { PrimaryGeneratedColumn, Column, OneToOne, CreateDateColumn, UpdateDateColumn, DeleteDateColumn, Entity } from "typeorm";
+import { DatabaseType } from "../common/config/database/database-type";
+import { Comment } from "./comment";
+
+@Entity({ name: "comment_content" })
+class CommentContent {
+    @PrimaryGeneratedColumn("increment", { type: "int" })
+    id;
+
+    @Column({ name: "content", type: process.env.DATABASE_TYPE === DatabaseType.MYSQL ? "mediumtext" : "varchar", charset: "utf-8" })
+    @IsString
+    content;
+
+    @CreateDateColumn({ name: "created_at", type: "datetime" })
+    createdAt;
+
+    @UpdateDateColumn({ name: "updated_at", type: "datetime" })
+    updatedAt;
+
+    @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
+    deletedAt;
+
+    @OneToOne(() => Comment, (comment) => comment.content)
+    comment;
+}
+
+export { CommentContent };

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -1,5 +1,16 @@
 import { IsString, IsUrl } from "class-validator";
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, DeleteDateColumn, JoinColumn } from "typeorm";
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+    ManyToOne,
+    DeleteDateColumn,
+    JoinColumn,
+    OneToOne
+} from "typeorm";
+import { CommentContent } from "./comment-content";
 import { Issue } from "./issue";
 import { User } from "./user";
 
@@ -7,11 +18,6 @@ import { User } from "./user";
 class Comment {
     @PrimaryGeneratedColumn("increment", { type: "int" })
     id;
-
-    @Column({ name: "content", type: "varchar" })
-    @IsString()
-    @IsUrl()
-    content;
 
     @CreateDateColumn({ name: "created_at", type: "datetime" })
     createdAt;
@@ -29,6 +35,10 @@ class Comment {
     @ManyToOne(() => User, (user) => user.comments)
     @JoinColumn({ name: "user_id" })
     user;
+
+    @OneToOne(() => CommentContent, (content) => content.comment)
+    @JoinColumn({ name: "content_id" })
+    content;
 }
 
 export { Comment };

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -1,5 +1,5 @@
 import { IsString, IsUrl } from "class-validator";
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, DeleteDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, DeleteDateColumn, JoinColumn } from "typeorm";
 import { Issue } from "./issue";
 import { User } from "./user";
 
@@ -22,10 +22,12 @@ class Comment {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @ManyToOne(() => Issue, (issue) => issue.id, { cascade: true, onDelete: "CASCADE" })
+    @ManyToOne(() => Issue, (issue) => issue.comments)
+    @JoinColumn({ name: "issue_id" })
     issue;
 
-    @ManyToOne(() => User, (user) => user.id, { cascade: true })
+    @ManyToOne(() => User, (user) => user.comments)
+    @JoinColumn({ name: "user_id" })
     user;
 }
 

--- a/backend/src/model/issue-content.js
+++ b/backend/src/model/issue-content.js
@@ -1,0 +1,28 @@
+import { IsString } from "class-validator";
+import { PrimaryGeneratedColumn, Column, OneToOne, CreateDateColumn, UpdateDateColumn, DeleteDateColumn, Entity } from "typeorm";
+import { DatabaseType } from "../common/config/database/database-type";
+import { Issue } from "./issue";
+
+@Entity({ name: "issue_content" })
+class IssueContent {
+    @PrimaryGeneratedColumn("increment", { type: "int" })
+    id;
+
+    @Column({ name: "content", type: process.env.DATABASE_TYPE === DatabaseType.MYSQL ? "mediumtext" : "varchar", charset: "utf-8" })
+    @IsString
+    content;
+
+    @CreateDateColumn({ name: "created_at", type: "datetime" })
+    createdAt;
+
+    @UpdateDateColumn({ name: "updated_at", type: "datetime" })
+    updatedAt;
+
+    @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
+    deletedAt;
+
+    @OneToOne(() => Issue, (issue) => issue.content)
+    issue;
+}
+
+export { IssueContent };

--- a/backend/src/model/issue.js
+++ b/backend/src/model/issue.js
@@ -7,15 +7,17 @@ import {
     OneToMany,
     ManyToOne,
     DeleteDateColumn,
-    JoinColumn
+    JoinColumn,
+    OneToOne
 } from "typeorm";
-import { IsString, IsUrl, IsOptional } from "class-validator";
+import { IsString, IsOptional } from "class-validator";
 import { Comment } from "./comment";
 import { User } from "./user";
 import { UserToIssue } from "./user-to-issue";
 import { Milestone } from "./milestone";
 import { LabelToIssue } from "./label-to-issue";
 import { ISSUESTATE } from "../common/type";
+import { IssueContent } from "./issue-content";
 
 @Entity({ name: "issue" })
 class Issue {
@@ -25,11 +27,6 @@ class Issue {
     @Column({ name: "title", type: "varchar", charset: "utf-8" })
     @IsString()
     title;
-
-    @Column({ name: "content", type: "varchar" })
-    @IsString()
-    @IsUrl()
-    content;
 
     @Column({ name: "state", type: "varchar", default: ISSUESTATE.OPEN })
     @IsOptional()
@@ -45,21 +42,25 @@ class Issue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => Comment, (comment) => comment.issue, { lazy: true })
+    @OneToMany(() => Comment, (comment) => comment.issue)
     comments;
 
-    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.issue, { lazy: true })
+    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.issue)
     userToIssues;
 
-    @ManyToOne(() => User, (user) => user.id, { eager: true })
+    @ManyToOne(() => User, (user) => user.id)
     @JoinColumn({ name: "author_id" })
     author;
 
-    @ManyToOne(() => Milestone, (milestone) => milestone.id, { eager: true })
+    @ManyToOne(() => Milestone, (milestone) => milestone.id)
     @JoinColumn({ name: "milestone_id" })
     milestone;
 
-    @OneToMany(() => LabelToIssue, (labelToIssue) => labelToIssue.issue, { lazy: true })
+    @OneToMany(() => LabelToIssue, (labelToIssue) => labelToIssue.issue)
     labelToIssues;
+
+    @OneToOne(() => IssueContent, (content) => content.issue)
+    @JoinColumn({ name: "content_id" })
+    content;
 }
 export { Issue };

--- a/backend/src/model/issue.js
+++ b/backend/src/model/issue.js
@@ -1,4 +1,14 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, OneToMany, ManyToOne, DeleteDateColumn } from "typeorm";
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+    OneToMany,
+    ManyToOne,
+    DeleteDateColumn,
+    JoinColumn
+} from "typeorm";
 import { IsString, IsUrl, IsOptional } from "class-validator";
 import { Comment } from "./comment";
 import { User } from "./user";
@@ -35,19 +45,21 @@ class Issue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => Comment, (comment) => comment.id)
+    @OneToMany(() => Comment, (comment) => comment.issue, { lazy: true })
     comments;
 
-    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.issue)
+    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.issue, { lazy: true })
     userToIssues;
 
-    @ManyToOne(() => User, (user) => user.id, { eager: true, cascade: true })
+    @ManyToOne(() => User, (user) => user.id, { eager: true })
+    @JoinColumn({ name: "author_id" })
     author;
 
-    @ManyToOne(() => Milestone, (milestone) => milestone.id, { eager: true, cascade: true })
+    @ManyToOne(() => Milestone, (milestone) => milestone.id, { eager: true })
+    @JoinColumn({ name: "milestone_id" })
     milestone;
 
-    @OneToMany(() => LabelToIssue, (labelToIssue) => labelToIssue.label)
+    @OneToMany(() => LabelToIssue, (labelToIssue) => labelToIssue.issue, { lazy: true })
     labelToIssues;
 }
 export { Issue };

--- a/backend/src/model/label-to-issue.js
+++ b/backend/src/model/label-to-issue.js
@@ -16,11 +16,11 @@ class LabelToIssue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @ManyToOne(() => Label, (label) => label.labelToIssues, { eager: true })
+    @ManyToOne(() => Label, (label) => label.labelToIssues)
     @JoinColumn({ name: "label_id" })
     label;
 
-    @ManyToOne(() => Issue, (issue) => issue.labelToIssues, { eager: true })
+    @ManyToOne(() => Issue, (issue) => issue.labelToIssues)
     @JoinColumn({ name: "issue_id" })
     issue;
 }

--- a/backend/src/model/label-to-issue.js
+++ b/backend/src/model/label-to-issue.js
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, DeleteDateColumn } from "typeorm";
+import { Entity, ManyToOne, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, DeleteDateColumn, JoinColumn } from "typeorm";
 import { Issue } from "./issue";
 import { Label } from "./label";
 
@@ -16,10 +16,12 @@ class LabelToIssue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @ManyToOne(() => Label, (label) => label.labelToIssues, { eager: true, cascade: true, onDelete: "CASCADE" })
+    @ManyToOne(() => Label, (label) => label.labelToIssues, { eager: true })
+    @JoinColumn({ name: "label_id" })
     label;
 
-    @ManyToOne(() => Issue, (issue) => issue.labelToIssues, { eager: true, cascade: true, onDelete: "CASCADE" })
+    @ManyToOne(() => Issue, (issue) => issue.labelToIssues, { eager: true })
+    @JoinColumn({ name: "issue_id" })
     issue;
 }
 

--- a/backend/src/model/label.js
+++ b/backend/src/model/label.js
@@ -30,7 +30,7 @@ class Label {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => LabelToIssue, (labelToIssues) => labelToIssues.label, { lazy: true })
+    @OneToMany(() => LabelToIssue, (labelToIssues) => labelToIssues.label)
     labelToIssues;
 }
 

--- a/backend/src/model/label.js
+++ b/backend/src/model/label.js
@@ -30,7 +30,7 @@ class Label {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => LabelToIssue, (labelToIssues) => labelToIssues.issue)
+    @OneToMany(() => LabelToIssue, (labelToIssues) => labelToIssues.label, { lazy: true })
     labelToIssues;
 }
 

--- a/backend/src/model/milestone.js
+++ b/backend/src/model/milestone.js
@@ -36,7 +36,7 @@ class Milestone {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => Issue, (issue) => issue.id)
+    @OneToMany(() => Issue, (issue) => issue.milestone)
     issues;
 }
 

--- a/backend/src/model/user-to-issue.js
+++ b/backend/src/model/user-to-issue.js
@@ -16,11 +16,11 @@ class UserToIssue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @ManyToOne(() => User, (user) => user.userToIssues, { eager: true })
+    @ManyToOne(() => User, (user) => user.userToIssues)
     @JoinColumn({ name: "user_id" })
     user;
 
-    @ManyToOne(() => Issue, (issue) => issue.userToIssues, { eager: true })
+    @ManyToOne(() => Issue, (issue) => issue.userToIssues)
     @JoinColumn({ name: "issue_id" })
     issue;
 }

--- a/backend/src/model/user-to-issue.js
+++ b/backend/src/model/user-to-issue.js
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, DeleteDateColumn } from "typeorm";
+import { Entity, ManyToOne, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, DeleteDateColumn, JoinColumn } from "typeorm";
 import { Issue } from "./issue";
 import { User } from "./user";
 
@@ -16,10 +16,12 @@ class UserToIssue {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @ManyToOne(() => User, (user) => user.userToIssues, { eager: true, cascade: true, onDelete: "CASCADE" })
+    @ManyToOne(() => User, (user) => user.userToIssues, { eager: true })
+    @JoinColumn({ name: "user_id" })
     user;
 
-    @ManyToOne(() => Issue, (issue) => issue.userToIssues, { eager: true, cascade: true, onDelete: "CASCADE" })
+    @ManyToOne(() => Issue, (issue) => issue.userToIssues, { eager: true })
+    @JoinColumn({ name: "issue_id" })
     issue;
 }
 

--- a/backend/src/model/user.js
+++ b/backend/src/model/user.js
@@ -31,13 +31,13 @@ class User {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.user)
+    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.user, { lazy: true })
     userToIssues;
 
-    @OneToMany(() => Issue, (issue) => issue.id)
+    @OneToMany(() => Issue, (issue) => issue.author, { lazy: true })
     issues;
 
-    @OneToMany(() => Comment, (comment) => comment.id)
+    @OneToMany(() => Comment, (comment) => comment.user, { lazy: true })
     comments;
 }
 

--- a/backend/src/model/user.js
+++ b/backend/src/model/user.js
@@ -31,13 +31,13 @@ class User {
     @DeleteDateColumn({ name: "deleted_at", type: "datetime" })
     deletedAt;
 
-    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.user, { lazy: true })
+    @OneToMany(() => UserToIssue, (userToIssue) => userToIssue.user)
     userToIssues;
 
-    @OneToMany(() => Issue, (issue) => issue.author, { lazy: true })
+    @OneToMany(() => Issue, (issue) => issue.author)
     issues;
 
-    @OneToMany(() => Comment, (comment) => comment.user, { lazy: true })
+    @OneToMany(() => Comment, (comment) => comment.user)
     comments;
 }
 


### PR DESCRIPTION
## 📕 제목

연관 관계 수정

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] ManyToOne 혹은 OneToMany에 두번째 인자가 잘못 되어서 전반적인 수정
- [x] JoinColumn을 통해서 FK가 되는 컬럼 명시적으로 선언
- [x] OneToMany Lazy Loading 명시적으로 선언
- [x] 불필요한 cascade 옵션 제거
- [x] IssueContent, CommentContent 선언
- [x] Lazy와 Eager 제거

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 불필요한 Cascade 옵션은 다 제거했습니다. 연관된 객체가 추가되거나 수정되었을 때 해당 내용을 데이터베이스에 반영할지 말지 결정하는 옵션인데, 비지니스 로직상 필요 없다고 생각했습니다! 예를 들어 comment를 데이터베이스에 insert할 때 커멘트에 연관된 issue를 함께 데이터베이스에 insert 합니다. 저흰 이미 issue가 데이터베이스에 존재하는 상태에서 comment를 생성하기 때문에 대부분의 경우 사용하지 않아도 됩니다. 일반적으로 OneToMany 관계에 cascade를 많이 설정합니다.
- onDelete는 데이터베이스의 FK 제약사항입니다. 예를 들어 issue가 삭제되었을 때 연관된 comment를 다 삭제합니다. 저희 프로젝트의 경우 soft delete 하기로 했으니까 사용하지 않아도 될 것 같습니다! 기본값은 NO ACTION (삭제를 못 함).
- onDelete는 데이터베이스 제약 조건, soft remove는 서버에서 추상화된 기능이므로 엄연히 다릅니다.
- cascade: ["soft-remove"] 옵션을 적용하면 연관 엔티티를 지울 수 있습니다 (예를 들어 issue를 soft remove할 때 연관된 comment, assignee, label 등을 선택해서 지울 수 있습니다.) 아직 적용 범위가 확실치 않으므로 로직을 짜면서 옵션을 적용해도 충분하다고 생각합니다.
- Lazy 옵션이 Typescript에서는 잘 적용이 되지만 Javascript에선 적용이 되지 않습니다ㅠㅠㅠㅠㅠ 그래서 Lazy를 전부 뺐습니다.
- Eager 옵션도 마찬가지로 뺐습니다. Eager 옵션으로 인해 항상 연관 엔티티를 가져오는 것이 비효율적일 수 있다고 생각했습니다. 추후에 개발하시는 분이 필요하다고 생각하면 추가하셔도 될 것 같아용. 
