### PR TITLE
헤더 컴포넌트 제작

### DIFF
--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -6,7 +6,15 @@ const color = {
     btn_primary_hover_bg: "#2c974b",
     btn_primary_border: "rgba(27, 31, 35, 0.15)",
     btn_primary_shadow: "rgba(27, 31, 35, 0.04)",
-    btn_primary_text: "#ffffff"
+    btn_primary_text: "#ffffff",
+    header_bg: "#24292e",
+    header_title_text: "#ffffff",
+    header_dropmenu_bg: "#ffffff",
+    header_dropmenu_hover_bg: "#0366d6",
+    header_dropmenu_text: "#1b1f23",
+    header_dropmenu_hover_text: "#ffffff",
+    header_dropmenu_boader: "#e1e4e8",
+    header_dropmenu_modal_bg: "transparent"
 };
 
 export { color };

--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -14,7 +14,8 @@ const color = {
     header_dropmenu_text: "#1b1f23",
     header_dropmenu_hover_text: "#ffffff",
     header_dropmenu_boader: "#e1e4e8",
-    header_dropmenu_modal_bg: "transparent"
+    header_dropmenu_modal_bg: "transparent",
+    caret_text: "#ffffff"
 };
 
 export { color };

--- a/frontend/src/components/Caret/Caret.jsx
+++ b/frontend/src/components/Caret/Caret.jsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { color } from "@style/color";
 
 const Caret = styled.span`
     display: inline-block;
@@ -11,7 +12,7 @@ const Caret = styled.span`
     border-right: 4px solid transparent;
     border-bottom: 0 solid transparent;
     border-left: 4px solid transparent;
-    color: #ffffff;
+    color: ${color.caret_text};
 `;
 
 export default Caret;

--- a/frontend/src/components/Caret/Caret.jsx
+++ b/frontend/src/components/Caret/Caret.jsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const Caret = styled.span`
+    display: inline-block;
+    width: 0;
+    height: 0;
+    vertical-align: middle;
+    content: "";
+    border-top-style: solid;
+    border-top-width: 4px;
+    border-right: 4px solid transparent;
+    border-bottom: 0 solid transparent;
+    border-left: 4px solid transparent;
+    color: #ffffff;
+`;
+
+export default Caret;

--- a/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
+++ b/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
@@ -1,0 +1,57 @@
+import React, { useReducer, useContext } from "react";
+import { UserContext } from "@context";
+import HeaderPresenter from "../HeaderPresenter/HeaderPresenter";
+import HeaderContext from "../HeaderContext/HeaderContext";
+
+const HEADER_ACTION_TYPE = {
+    SHOW_DROPMENU: "showDropmenu",
+    HIDE_DROPMENU: "hideDropmenu"
+};
+
+const reducer = (headerState, action) => {
+    switch (action.type) {
+        case HEADER_ACTION_TYPE.SHOW_DROPMENU:
+            return { ...headerState, isHiddenDropmenu: false };
+        case HEADER_ACTION_TYPE.HIDE_DROPMENU:
+            return { ...headerState, isHiddenDropmenu: true };
+        default:
+            throw new Error();
+    }
+};
+
+const HeaderContainer = () => {
+    const { photoImage, name, email } = useContext(UserContext);
+    const initialState = {
+        userProfileImage: photoImage,
+        userStatusMenus: [`Signed in as ${name}`, `${email}`],
+        navigationMenus: ["Your profile", "Your repository", "Your enterprises", "Your projects", "Your stars", "Your gists"],
+        serviceMenus: ["Help", "Sign out"],
+        isHiddenDropmenu: true
+    };
+    const [headerState, dispatch] = useReducer(reducer, initialState);
+
+    const eventListeners = {
+        onDropmenuClickListner: (e) => {
+            e.preventDefault();
+
+            if (headerState.isHiddenDropmenu) {
+                dispatch({ type: HEADER_ACTION_TYPE.SHOW_DROPMENU });
+                return;
+            }
+            dispatch({ type: HEADER_ACTION_TYPE.HIDE_DROPMENU });
+        },
+
+        onModalBackgrondClickListener: (e) => {
+            e.preventDefault();
+            if (!headerState.isHiddenDropmenu) dispatch({ type: HEADER_ACTION_TYPE.HIDE_DROPMENU });
+        }
+    };
+
+    return (
+        <HeaderContext.Provider value={{ headerState, dispatch, eventListeners }}>
+            <HeaderPresenter />
+        </HeaderContext.Provider>
+    );
+};
+
+export default HeaderContainer;

--- a/frontend/src/components/Header/HeaderContext/HeaderContext.jsx
+++ b/frontend/src/components/Header/HeaderContext/HeaderContext.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const HeaderContext = React.createContext();
+
+export default HeaderContext;

--- a/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
@@ -1,0 +1,130 @@
+import React, { useContext } from "react";
+import styled, { css } from "styled-components";
+import { UserProfile, Caret } from "@components";
+import HeaderContext from "../../HeaderContext/HeaderContext";
+
+const DropmenuContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+`;
+
+const DropmenuButton = styled.button`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    width: 50px;
+    cursor: pointer;
+    z-index: 2000;
+`;
+
+const DropmenuModalBackground = styled.div`
+    display: ${(props) => (props.isHidden ? "none" : "block")};
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    background-color: transparent;
+    z-index: 1000;
+`;
+
+const DropmenuList = styled.ul`
+    display: ${(props) => (props.isHidden ? "none" : "block")};
+    position: absolute;
+    top: 100%;
+    right: 15px;
+    color: #1b1f23;
+    background-color: #ffffff;
+    border: 1px solid #e1e4e8;
+    border-radius: 6px;
+    white-space: nowrap;
+    z-index: 2000;
+
+    &:after {
+        position: absolute;
+        display: inline-block;
+        content: "";
+        top: -14px;
+        right: 10px;
+        left: auto;
+        border: 7px solid transparent;
+        border-bottom: 7px solid #ffffff;
+    }
+`;
+
+const DropmenuMainArea = styled.li`
+    padding: 8px 0px;
+    border-bottom: 1px solid #e1e4e8;
+    &:last-of-type {
+        border-bottom: none;
+    }
+`;
+
+const DropmenuSubArea = styled.ul`
+    & > li {
+        padding: 4px 16px;
+        font-size: 13px;
+        cursor: pointer;
+        &:hover {
+            color: #ffffff;
+            background-color: #0366d6;
+        }
+    }
+    ${(props) =>
+        props.statusMenu &&
+        css`
+            & > li {
+                &:hover {
+                    color: #1b1f23;
+                    background-color: #ffffff;
+                }
+            }
+        `}
+`;
+
+const DropmenuSubItem = ({ children, ...rest }) => {
+    return (
+        <li>
+            <span>{children}</span>
+        </li>
+    );
+};
+
+const HeaderDropmenu = () => {
+    const { headerState, eventListeners } = useContext(HeaderContext);
+
+    const getTotalMenus = () => {
+        const getMenuItems = (menus) => menus.reduce((acc, cur, idx) => acc.concat(<DropmenuSubItem key={idx}>{cur}</DropmenuSubItem>), []);
+
+        const getMenuItemAreas = ({ userStatusMenus, navigationMenus, serviceMenus }) =>
+            [userStatusMenus, navigationMenus, serviceMenus].reduce(
+                (acc, cur, idx) =>
+                    acc.concat(
+                        <DropmenuMainArea>
+                            <DropmenuSubArea statusMenu={idx === 0}>{getMenuItems(cur)}</DropmenuSubArea>
+                        </DropmenuMainArea>
+                    ),
+                []
+            );
+
+        return getMenuItemAreas(headerState);
+    };
+
+    return (
+        <DropmenuContainer>
+            <DropmenuButton type="button" onClick={eventListeners.onDropmenuClickListner}>
+                <UserProfile imageUrl={headerState.userProfileImage} />
+                <Caret />
+            </DropmenuButton>
+            <DropmenuModalBackground isHidden={headerState.isHiddenDropmenu} onClick={eventListeners.onModalBackgrondClickListener} />
+            <DropmenuList isHidden={headerState.isHiddenDropmenu}>{getTotalMenus()}</DropmenuList>
+        </DropmenuContainer>
+    );
+};
+
+export default HeaderDropmenu;

--- a/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import styled, { css } from "styled-components";
 import { UserProfile, Caret } from "@components";
+import { color } from "@style/color";
 import HeaderContext from "../../HeaderContext/HeaderContext";
 
 const DropmenuContainer = styled.div`
@@ -29,7 +30,7 @@ const DropmenuModalBackground = styled.div`
     right: 0;
     width: 100%;
     height: 100%;
-    background-color: transparent;
+    background-color: ${color.header_dropmenu_modal_bg};
     z-index: 1000;
 `;
 
@@ -38,9 +39,9 @@ const DropmenuList = styled.ul`
     position: absolute;
     top: 100%;
     right: 15px;
-    color: #1b1f23;
-    background-color: #ffffff;
-    border: 1px solid #e1e4e8;
+    color: ${color.header_dropmenu_text};
+    background-color: ${color.header_dropmenu_bg};
+    border: 1px solid ${color.header_dropmenu_boader};
     border-radius: 6px;
     white-space: nowrap;
     z-index: 2000;
@@ -53,13 +54,13 @@ const DropmenuList = styled.ul`
         right: 10px;
         left: auto;
         border: 7px solid transparent;
-        border-bottom: 7px solid #ffffff;
+        border-bottom: 7px solid ${color.header_dropmenu_bg};
     }
 `;
 
 const DropmenuMainArea = styled.li`
     padding: 8px 0px;
-    border-bottom: 1px solid #e1e4e8;
+    border-bottom: 1px solid ${color.header_dropmenu_boader};
     &:last-of-type {
         border-bottom: none;
     }
@@ -71,8 +72,8 @@ const DropmenuSubArea = styled.ul`
         font-size: 13px;
         cursor: pointer;
         &:hover {
-            color: #ffffff;
-            background-color: #0366d6;
+            color: ${color.header_dropmenu_hover_text};
+            background-color: ${color.header_dropmenu_hover_bg};
         }
     }
     ${(props) =>
@@ -80,8 +81,8 @@ const DropmenuSubArea = styled.ul`
         css`
             & > li {
                 &:hover {
-                    color: #1b1f23;
-                    background-color: #ffffff;
+                    color: ${color.header_dropmenu_text};
+                    background-color: ${color.header_dropmenu_bg};
                 }
             }
         `}

--- a/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 import HeaderTitle from "./HeaderTitle/HeaderTitle";
 import HeaderDropmenu from "./HeaderDropmenu/HeaderDropmenu";
 
@@ -8,8 +9,7 @@ const StyledHeader = styled.header`
     justify-content: center;
     width: 100%;
     padding: 15px 30px;
-    color: #ffffff;
-    background-color: #24292e;
+    background-color: ${color.header_bg};
     box-sizing: border-box;
 `;
 

--- a/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
@@ -4,7 +4,7 @@ import { color } from "@style/color";
 import HeaderTitle from "./HeaderTitle/HeaderTitle";
 import HeaderDropmenu from "./HeaderDropmenu/HeaderDropmenu";
 
-const StyledHeader = styled.header`
+const HeaderArea = styled.header`
     display: flex;
     justify-content: center;
     width: 100%;
@@ -13,7 +13,7 @@ const StyledHeader = styled.header`
     box-sizing: border-box;
 `;
 
-const HeaderArea = styled.div`
+const HeaderContent = styled.div`
     display: flex;
     justify-content: center;
     position: relative;
@@ -22,12 +22,12 @@ const HeaderArea = styled.div`
 
 const HeaderPresenter = () => {
     return (
-        <StyledHeader>
-            <HeaderArea>
+        <HeaderArea>
+            <HeaderContent>
                 <HeaderTitle />
                 <HeaderDropmenu />
-            </HeaderArea>
-        </StyledHeader>
+            </HeaderContent>
+        </HeaderArea>
     );
 };
 

--- a/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "styled-components";
+import HeaderTitle from "./HeaderTitle/HeaderTitle";
+import HeaderDropmenu from "./HeaderDropmenu/HeaderDropmenu";
+
+const StyledHeader = styled.header`
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    padding: 15px 30px;
+    color: #ffffff;
+    background-color: #24292e;
+    box-sizing: border-box;
+`;
+
+const HeaderArea = styled.div`
+    display: flex;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+`;
+
+const HeaderPresenter = () => {
+    return (
+        <StyledHeader>
+            <HeaderArea>
+                <HeaderTitle />
+                <HeaderDropmenu />
+            </HeaderArea>
+        </StyledHeader>
+    );
+};
+
+export default HeaderPresenter;

--- a/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
@@ -3,29 +3,29 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { color } from "@style/color";
 
-const StyledLink = styled(Link)`
+const HeaderLogoLink = styled(Link)`
     display: flex;
     align-items: center;
     font-size: 17px;
     font-weight: 600;
 `;
 
-const StyledImg = styled.img`
+const HeaderLogoImg = styled.img`
     width: 32px;
     height: 32px;
     margin-right: 5px;
 `;
 
-const StyledSpan = styled.span`
+const HeaderLogoTitle = styled.span`
     color: ${color.header_title_text};
 `;
 
 const HeaderTitle = () => {
     return (
-        <StyledLink to="/">
-            <StyledImg src="https://user-images.githubusercontent.com/32856129/98276858-ef6a0880-1fd9-11eb-9473-c8844c066cce.png" />
-            <StyledSpan>SnailHub</StyledSpan>
-        </StyledLink>
+        <HeaderLogoLink to="/">
+            <HeaderLogoImg src="https://user-images.githubusercontent.com/32856129/98276858-ef6a0880-1fd9-11eb-9473-c8844c066cce.png" />
+            <HeaderLogoTitle>SnailHub</HeaderLogoTitle>
+        </HeaderLogoLink>
     );
 };
 

--- a/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+const StyledLink = styled(Link)`
+    display: flex;
+    align-items: center;
+    font-size: 17px;
+    font-weight: 600;
+`;
+
+const StyledImg = styled.img`
+    width: 32px;
+    height: 32px;
+    margin-right: 5px;
+`;
+
+const StyledSpan = styled.span`
+    color: #ffffff;
+`;
+
+const HeaderTitle = () => {
+    return (
+        <StyledLink to="/">
+            <StyledImg src="https://user-images.githubusercontent.com/32856129/98276858-ef6a0880-1fd9-11eb-9473-c8844c066cce.png" />
+            <StyledSpan>SnailHub</StyledSpan>
+        </StyledLink>
+    );
+};
+
+export default HeaderTitle;

--- a/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderTitle/HeaderTitle.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { color } from "@style/color";
 
 const StyledLink = styled(Link)`
     display: flex;
@@ -16,7 +17,7 @@ const StyledImg = styled.img`
 `;
 
 const StyledSpan = styled.span`
-    color: #ffffff;
+    color: ${color.header_title_text};
 `;
 
 const HeaderTitle = () => {

--- a/frontend/src/components/UserProfile/UserProfile.jsx
+++ b/frontend/src/components/UserProfile/UserProfile.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styled from "styled-components";
+
+const StyledImg = styled.img`
+    width: 20px;
+    height: 20px;
+    overflow: hidden;
+    line-height: 1;
+    vertical-align: middle;
+    border-radius: 50% !important;
+`;
+
+const UserProfile = ({ imageUrl }) => {
+    return <StyledImg src={imageUrl} />;
+};
+
+export default UserProfile;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,2 +1,5 @@
 export { default as LoginForm } from "./LoginForm/LoginForm";
 export { default as Button } from "./Button/Button";
+export { default as Header } from "./Header/HeaderContainer/HeaderContainer";
+export { default as UserProfile } from "./UserProfile/UserProfile";
+export { default as Caret } from "./Caret/Caret";

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -5,6 +5,7 @@ import { usePromise } from "@hook";
 import axios from "axios";
 import { UserContext } from "@context";
 import Config from "@config";
+import { Header } from "@components";
 
 const Main = styled.main`
     height: 100%;
@@ -25,6 +26,7 @@ const MainPage = () => {
 
     return (
         <UserContext.Provider value={resolved.data}>
+            <Header />
             <Main>
                 <h1>메인페이지입니다</h1>
             </Main>


### PR DESCRIPTION
## 📕 제목

헤더 컴포넌트 제작
관련 이슈 #67 #66 #12 


## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 헤더 컴포넌트 제작
- [x] 사용자 프로필 사진 컴포넌트 제작
- [x] Caret 컴포넌트 제작

![ezgif com-gif-maker](https://user-images.githubusercontent.com/32856129/98450054-a30afe00-217c-11eb-99ad-787236f5a14e.gif)
- 모달방식으로 구현하여 프로필을 클릭하거나, 프로필/메뉴 부분이 아닌 다른 곳을 클릭하였을 때 사라지도록 구현하였습니다 :-)
- 로고이미지는 하드코딩되어있습니다. 공통이미지 추가 후, 변경할게요 :-)



## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 헤더 컴포넌트를 제작하면서 컴포넌트를 세세하게 분리하고, context API와 reducer 활용을 연습해보는 것을 초점으로 제작하였습니다.
- 헤더 컴포넌트는 크게 세 부분으로 나누어구현하였습니다.
  - HeaderContainer : 헤더의 렌더링에 필요한 모든 state와 state 변경을 위한 이벤트리스너를 포함합니다.
    - 하위 컴포넌트에게 state를 전달하기 위해 HeaderContext를 활용하였습니다.
    - 하위 컴포넌트가 state를 쉽게 변경할 수 있도록 reducer를 활용하였습니다.
    - 사용자 인터렉션을 위해 dispatch가 필요한 경우, container에서 이벤트리스너를 정의하고, 해당 리스너를 context로 하위 컴포넌트로 전달해 활용하였습니다.
  - HeaderPresenter : 헤더의 렌더링을 위한 모든 view를 포함합니다. 
    - Presenter안에서 필요한 경우 세세하게 styled componet로 분리하였습니다.
    - styled component의 경우, 모두 파일로 분리하면 파일이 너무 많아질 수 있으므로, 아직 파일의 크기가 크지않다고 판단하여 별도로 분리하지 않았습니다.
  - HeaderContext : 하위 컴포넌트에게 state 정보를 쉽게 전달하기위한 context입니다.
    - Header안에서만 활용되므로 common/context에 폴더가 아닌 헤더 폴더안에 파일을 위치시켰습니다.
- 헤더 컴포넌트 제작 후, 메인 페이지에서 UserContext를 통해 로그인된 회원 정보를 받아 name, email, profileImage 정보를 활용해 렌더링 하도록 메인페이지에 헤더를 추가하였습니다.
- 추가 공통 컴포넌트를 제작하였습니다.
  - UserProfile : 사용자 프로필 사진을 보여주는 컴포넌트입니다. 재사용이 필요할 것 같아 분리시켰습니다.
  - Caret : GitHub에서 불필요한 이미지 로딩을 줄이기 위해 CSS를 활용한 것으로 보여, styled component로 제작하고, 재사용이 가능하도록 분리시켰습니다.