### PR TITLE
feat: [FE] Label 사이즈 조절

### DIFF
--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -15,7 +15,7 @@ const color = {
     tab_bg: "#f6f8fa",
     tab_selected_bg: "#ffffff",
     tab_container_gb: "#ffffff",
-    border_primary: "#e1e4e8"
+    border_primary: "#e1e4e8",
     register_btn: "#2e9afe",
     loading_dots: "#d8d8d8",
     sidemenu_hover: "#2e9afe",

--- a/frontend/src/components/Label/Label.jsx
+++ b/frontend/src/components/Label/Label.jsx
@@ -13,12 +13,15 @@ const StyledLabel = styled.button`
     background-color: ${(props) => props.color};
     color: ${(props) => defineTextColor(props.color)};
     border-radius: 1rem;
-    font-size: 14px;
+    font-size: 10px;
+    line-height: 2;
     font-weight: bold;
     cursor: pointer;
-    line-height: 20px;
-    padding: 5px 16px;
     border: none;
+    margin-left: 2.5px;
+    margin-right: 2.5px;
+    padding-left: 10px;
+    padding-right: 10px;
     &:hover {
         text-decoration: underline;
     }


### PR DESCRIPTION
## 📕 제목

#80 
![image](https://user-images.githubusercontent.com/46101366/98630558-c392ae00-235e-11eb-82ac-496eb49ea44e.png)

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [ ] Font-Size 조절
- [ ] Line-Height 수정
- [ ] padding 및 margin 설정
- [ ] color.js에 , 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Label 목록 화면에선 mouseover시 text-decorator : underline이 설정되는데 Issue 화면엔선 그렇지 않다는 걸 발견했네요. 이걸 따로 수정할지 말지는 작업 속도에 따라 결정하겠습니다!
- color.js가 merge 과정에서 ,가 하나빠져서 컴파일 에러가 발생합니다. 이걸 빠르게 merge 시켜도 되고 각자 개발 환경에서 ,를 추가해서 컴파일 하시면 에러가 안 뜰것 같네요.