### PR TITLE
feat: [FE] ListGroup 컴포넌트 제작 및 IssueItem 컴포넌트 제작

### DIFF
--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -18,7 +18,17 @@ const color = {
     header_dropmenu_hover_text: "#ffffff",
     header_dropmenu_boader: "#e1e4e8",
     header_dropmenu_modal_bg: "transparent",
-    caret_text: "#ffffff"
+    caret_text: "#ffffff",
+    issue_drop_btn: "#6a737d",
+    issue_drop_hover_btn: "#444d56",
+    issue_drop_modal_bg: "transparent",
+    issue_item_title: "#0366d6",
+    issue_item_detail_info_text: "#6a737d",
+    issue_item_milestone_title: "#6a737d",
+    list_group_header_bg: "#f6f8fa",
+    list_group_item_bg: "#ffffff",
+    list_group_item_hover_bg: "#f6f8fa",
+    list_group_border: "#eaecef"
 };
 
 export { color };

--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -25,6 +25,7 @@ const color = {
     issue_item_title: "#0366d6",
     issue_item_detail_info_text: "#6a737d",
     issue_item_milestone_title: "#6a737d",
+    list_group_header_border: "#eaecef",
     list_group_header_bg: "#f6f8fa",
     list_group_item_bg: "#ffffff",
     list_group_item_hover_bg: "#f6f8fa",

--- a/frontend/src/components/Caret/Caret.jsx
+++ b/frontend/src/components/Caret/Caret.jsx
@@ -12,7 +12,7 @@ const Caret = styled.span`
     border-right: 4px solid transparent;
     border-bottom: 0 solid transparent;
     border-left: 4px solid transparent;
-    color: ${color.caret_text};
+    color: ${(props) => (props.primary ? color.caret_text : "#586069")};
 `;
 
 export default Caret;

--- a/frontend/src/components/Checkbox/Checkbox.jsx
+++ b/frontend/src/components/Checkbox/Checkbox.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Checkbox = () => {
+    return <input type="checkbox" />;
+};
+
+export default Checkbox;

--- a/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
+++ b/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
@@ -23,21 +23,30 @@ const HeaderContainer = () => {
     const { photoImage, name, email } = useContext(UserContext);
     const initialState = {
         userProfileImage: photoImage,
-        userStatusMenus: [
-            { id: 1, title: `Signed in as ${name}` },
-            { id: 2, title: `${email}` }
-        ],
-        navigationMenus: [
-            { id: 1, title: "Your profile" },
-            { id: 2, title: "Your repository" },
-            { id: 3, title: "Your enterprises" },
-            { id: 4, title: "Your stars" },
-            { id: 5, title: "Your gists" }
-        ],
-        serviceMenus: [
-            { id: 1, title: "Help" },
-            { id: 2, title: "Sign out" }
-        ],
+        userStatusMenus: {
+            id: 1,
+            menus: [
+                { id: 1, title: `Signed in as ${name}` },
+                { id: 2, title: `${email}` }
+            ]
+        },
+        navigationMenus: {
+            id: 2,
+            menus: [
+                { id: 1, title: "Your profile" },
+                { id: 2, title: "Your repository" },
+                { id: 3, title: "Your enterprises" },
+                { id: 4, title: "Your stars" },
+                { id: 5, title: "Your gists" }
+            ]
+        },
+        serviceMenus: {
+            id: 3,
+            menus: [
+                { id: 1, title: "Help" },
+                { id: 2, title: "Sign out" }
+            ]
+        },
         isHiddenDropmenu: true
     };
     const [headerState, dispatch] = useReducer(reducer, initialState);

--- a/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
+++ b/frontend/src/components/Header/HeaderContainer/HeaderContainer.jsx
@@ -23,9 +23,21 @@ const HeaderContainer = () => {
     const { photoImage, name, email } = useContext(UserContext);
     const initialState = {
         userProfileImage: photoImage,
-        userStatusMenus: [`Signed in as ${name}`, `${email}`],
-        navigationMenus: ["Your profile", "Your repository", "Your enterprises", "Your projects", "Your stars", "Your gists"],
-        serviceMenus: ["Help", "Sign out"],
+        userStatusMenus: [
+            { id: 1, title: `Signed in as ${name}` },
+            { id: 2, title: `${email}` }
+        ],
+        navigationMenus: [
+            { id: 1, title: "Your profile" },
+            { id: 2, title: "Your repository" },
+            { id: 3, title: "Your enterprises" },
+            { id: 4, title: "Your stars" },
+            { id: 5, title: "Your gists" }
+        ],
+        serviceMenus: [
+            { id: 1, title: "Help" },
+            { id: 2, title: "Sign out" }
+        ],
         isHiddenDropmenu: true
     };
     const [headerState, dispatch] = useReducer(reducer, initialState);

--- a/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
@@ -105,8 +105,8 @@ const HeaderDropmenu = () => {
             [userStatusMenus, navigationMenus, serviceMenus].reduce(
                 (acc, cur, idx) =>
                     acc.concat(
-                        <DropmenuMainArea key={idx}>
-                            <DropmenuSubArea statusMenu={idx === 0}>{getMenuItems(cur)}</DropmenuSubArea>
+                        <DropmenuMainArea key={cur.id}>
+                            <DropmenuSubArea statusMenu={idx === 0}>{getMenuItems(cur.menus)}</DropmenuSubArea>
                         </DropmenuMainArea>
                     ),
                 []

--- a/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
@@ -20,7 +20,6 @@ const DropmenuButton = styled.button`
     position: relative;
     width: 50px;
     cursor: pointer;
-    z-index: 2000;
 `;
 
 const DropmenuModalBackground = styled.div`
@@ -100,13 +99,13 @@ const HeaderDropmenu = () => {
     const { headerState, eventListeners } = useContext(HeaderContext);
 
     const getTotalMenus = () => {
-        const getMenuItems = (menus) => menus.reduce((acc, cur, idx) => acc.concat(<DropmenuSubItem key={idx}>{cur}</DropmenuSubItem>), []);
+        const getMenuItems = (menus) => menus.reduce((acc, cur) => acc.concat(<DropmenuSubItem key={cur.id}>{cur.title}</DropmenuSubItem>), []);
 
         const getMenuItemAreas = ({ userStatusMenus, navigationMenus, serviceMenus }) =>
             [userStatusMenus, navigationMenus, serviceMenus].reduce(
                 (acc, cur, idx) =>
                     acc.concat(
-                        <DropmenuMainArea>
+                        <DropmenuMainArea key={idx}>
                             <DropmenuSubArea statusMenu={idx === 0}>{getMenuItems(cur)}</DropmenuSubArea>
                         </DropmenuMainArea>
                     ),
@@ -120,7 +119,7 @@ const HeaderDropmenu = () => {
         <DropmenuContainer>
             <DropmenuButton type="button" onClick={eventListeners.onDropmenuClickListner}>
                 <UserProfile imageUrl={headerState.userProfileImage} />
-                <Caret />
+                <Caret primary />
             </DropmenuButton>
             <DropmenuModalBackground isHidden={headerState.isHiddenDropmenu} onClick={eventListeners.onModalBackgrondClickListener} />
             <DropmenuList isHidden={headerState.isHiddenDropmenu}>{getTotalMenus()}</DropmenuList>

--- a/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
@@ -1,0 +1,118 @@
+import React, { useContext } from "react";
+import { ListGroup, UserProfile } from "@components";
+import styled from "styled-components";
+import IssueFilterMenuContext from "../IssueFilterMenuContext/IssueFilterMenuContext";
+
+const FILTER_TYPE = {
+    AUTHOR: "Author",
+    LABEL: "Label",
+    MILESTONES: "Milestones",
+    ASSIGNEE: "Assignee",
+    MARK_AS: "Mark as"
+};
+
+const FilterItemArea = styled.div`
+    display: flex;
+    cursor: pointer;
+    & > * {
+        margin-right: 5px;
+    }
+`;
+
+const IssueFilterDropmenuHeader = styled(ListGroup.Header)`
+    padding: 13px 18px;
+`;
+
+const IssueFilterDropmenuItem = styled(ListGroup.Item)`
+    padding: 13px 18px;
+`;
+
+const ProfileItemArea = styled(FilterItemArea)`
+    align-items: center;
+`;
+
+const ProfileItem = ({ id, name, profileImage }) => {
+    return (
+        <IssueFilterDropmenuItem>
+            <ProfileItemArea>
+                <UserProfile imageUrl={profileImage} />
+                <span>{name}</span>
+            </ProfileItemArea>
+        </IssueFilterDropmenuItem>
+    );
+};
+
+const LabelColor = styled.span`
+    width: 13px;
+    height: 13px;
+    border-radius: 3px;
+    background-color: ${(props) => props.color};
+`;
+
+const LabelInfoArea = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const LabelDescription = styled.span`
+    font-size: 12px;
+`;
+
+const LabelItem = ({ id, name, description, color }) => {
+    return (
+        <IssueFilterDropmenuItem>
+            <FilterItemArea>
+                <LabelColor color={color}> </LabelColor>
+                <LabelInfoArea>
+                    <span>{name}</span>
+                    {description !== "" ? <LabelDescription>{description}</LabelDescription> : ""}
+                </LabelInfoArea>
+            </FilterItemArea>
+        </IssueFilterDropmenuItem>
+    );
+};
+
+const MilestoneItem = ({ id, title }) => {
+    return (
+        <IssueFilterDropmenuItem>
+            <FilterItemArea>
+                <span>{title}</span>
+            </FilterItemArea>
+        </IssueFilterDropmenuItem>
+    );
+};
+
+const IssueFilterDropmenu = ({ filterType, title }) => {
+    const { issueFilterMenuState } = useContext(IssueFilterMenuContext);
+
+    const getDropmenuItems = () => {
+        const { athors, labels, milestones, assignees } = issueFilterMenuState;
+
+        switch (filterType) {
+            case FILTER_TYPE.AUTHOR:
+                return athors.reduce((acc, cur) => acc.concat(<ProfileItem key={cur.id} name={cur.name} profileImage={cur.profileImage} />), []);
+            case FILTER_TYPE.LABEL:
+                return labels.reduce(
+                    (acc, cur) => acc.concat(<LabelItem key={cur.id} name={cur.name} description={cur.description} color={cur.color} />),
+                    []
+                );
+            case FILTER_TYPE.MILESTONES:
+                return milestones.reduce((acc, cur) => acc.concat(<MilestoneItem key={cur.id} title={cur.title} />), []);
+            case FILTER_TYPE.ASSIGNEE:
+                return assignees.reduce((acc, cur) => acc.concat(<ProfileItem key={cur.id} name={cur.name} profileImage={cur.profileImage} />), []);
+            default:
+                return <></>;
+        }
+    };
+
+    return (
+        <ListGroup.Area>
+            <IssueFilterDropmenuHeader>
+                <span>Filter by {title}</span>
+            </IssueFilterDropmenuHeader>
+            <ListGroup.ItemList>{getDropmenuItems()}</ListGroup.ItemList>
+        </ListGroup.Area>
+    );
+};
+
+export default IssueFilterDropmenu;

--- a/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
@@ -86,11 +86,11 @@ const IssueFilterDropmenu = ({ filterType, title }) => {
     const { issueFilterMenuState } = useContext(IssueFilterMenuContext);
 
     const getDropmenuItems = () => {
-        const { athors, labels, milestones, assignees } = issueFilterMenuState;
+        const { authors, labels, milestones, assignees } = issueFilterMenuState;
 
         switch (filterType) {
             case FILTER_TYPE.AUTHOR:
-                return athors.reduce((acc, cur) => acc.concat(<ProfileItem key={cur.id} name={cur.name} profileImage={cur.profileImage} />), []);
+                return authors.reduce((acc, cur) => acc.concat(<ProfileItem key={cur.id} name={cur.name} profileImage={cur.profileImage} />), []);
             case FILTER_TYPE.LABEL:
                 return labels.reduce(
                     (acc, cur) => acc.concat(<LabelItem key={cur.id} name={cur.name} description={cur.description} color={cur.color} />),

--- a/frontend/src/components/IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer.jsx
@@ -35,7 +35,7 @@ const IssueFilterMenuContainer = () => {
             { id: 3, title: "Milestones", isHiddenDropmenu: true },
             { id: 4, title: "Assignee", isHiddenDropmenu: true }
         ],
-        athors: [
+        authors: [
             {
                 id: 1,
                 name: "woojini",

--- a/frontend/src/components/IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer.jsx
@@ -1,0 +1,111 @@
+import React, { useReducer } from "react";
+import IssueFilterMenuContext from "../IssueFilterMenuContext/IssueFilterMenuContext";
+import IssueFilterMenuPresenter from "../IssueFilterMenuPresenter/IssueFilterMenuPresenter";
+
+const ISSUE_FILTER_ACTION_TYPE = {
+    CHANGE_DROPMENU: "changeDropmenu",
+    HIDE_DROPMENU: "hideDropmenu"
+};
+
+const reducer = (issueFilterMenuState, action) => {
+    const { issueFilterMenus } = issueFilterMenuState;
+
+    let newIssueFilterMenus;
+    switch (action.type) {
+        case ISSUE_FILTER_ACTION_TYPE.CHANGE_DROPMENU:
+            newIssueFilterMenus = issueFilterMenus.reduce((acc, cur) => {
+                if (cur.id === Number(action.clickedMenuId) && cur.isHiddenDropmenu) return acc.concat({ ...cur, isHiddenDropmenu: false });
+                return acc.concat({ ...cur, isHiddenDropmenu: true });
+            }, []);
+            break;
+        case ISSUE_FILTER_ACTION_TYPE.HIDE_DROPMENU:
+            newIssueFilterMenus = issueFilterMenus.reduce((acc, cur) => acc.concat({ ...cur, isHiddenDropmenu: true }), []);
+            break;
+        default:
+            throw new Error();
+    }
+    return { ...issueFilterMenuState, issueFilterMenus: newIssueFilterMenus };
+};
+
+const IssueFilterMenuContainer = () => {
+    const initialState = {
+        issueFilterMenus: [
+            { id: 1, title: "Author", isHiddenDropmenu: true },
+            { id: 2, title: "Label", isHiddenDropmenu: true },
+            { id: 3, title: "Milestones", isHiddenDropmenu: true },
+            { id: 4, title: "Assignee", isHiddenDropmenu: true }
+        ],
+        athors: [
+            {
+                id: 1,
+                name: "woojini",
+                profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+            },
+            {
+                id: 2,
+                name: "Do-Ho",
+                profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+            }
+        ],
+        labels: [
+            {
+                id: 1,
+                name: "back-end",
+                description: "",
+                color: "#85f97a"
+            },
+            {
+                id: 2,
+                name: "modify",
+                description: "",
+                color: "#4f8ec1"
+            }
+        ],
+        milestones: [
+            {
+                id: 1,
+                title: "Back-end"
+            },
+            {
+                id: 2,
+                title: "Front-end"
+            }
+        ],
+        assignees: [
+            {
+                id: 1,
+                name: "woojini",
+                profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+            },
+            {
+                id: 2,
+                name: "Do-Ho",
+                profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+            }
+        ]
+    };
+    const [issueFilterMenuState, dispatch] = useReducer(reducer, initialState);
+
+    const eventListeners = {
+        onFilterDromButtonClickListener: (e) => {
+            e.preventDefault();
+            const evenTarget = e.target;
+            const BtnNode = evenTarget.dataset.id ? evenTarget : evenTarget.parentElement;
+            const issueFilterMenuId = BtnNode.dataset.id;
+
+            dispatch({ type: ISSUE_FILTER_ACTION_TYPE.CHANGE_DROPMENU, clickedMenuId: issueFilterMenuId });
+        },
+        onModalBackgrondClickListener: (e) => {
+            e.preventDefault();
+            dispatch({ type: ISSUE_FILTER_ACTION_TYPE.HIDE_DROPMENU });
+        }
+    };
+
+    return (
+        <IssueFilterMenuContext.Provider value={{ issueFilterMenuState, dispatch, eventListeners }}>
+            <IssueFilterMenuPresenter />
+        </IssueFilterMenuContext.Provider>
+    );
+};
+
+export default IssueFilterMenuContainer;

--- a/frontend/src/components/IssueFilterMenu/IssueFilterMenuContext/IssueFilterMenuContext.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterMenuContext/IssueFilterMenuContext.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const IssueFilterMenuContext = React.createContext();
+
+export default IssueFilterMenuContext;

--- a/frontend/src/components/IssueFilterMenu/IssueFilterMenuPresenter/IssueFilterMenuPresenter.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterMenuPresenter/IssueFilterMenuPresenter.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 import { Checkbox, Caret } from "@components";
 import IssueFilterMenuContext from "../IssueFilterMenuContext/IssueFilterMenuContext";
 import IssueFilterDropmenu from "../IssueFilterDropmenu/IssueFilterDropmenu";
@@ -25,10 +26,10 @@ const IssueDropButton = styled.button`
     position: relative;
     & > span {
         margin-right: 5px;
-        color: #6a737d;
+        color: ${color.issue_drop_btn};
     }
     &:hover > span {
-        color: #444d56;
+        color: ${color.issue_drop_hover_btn};
     }
 `;
 
@@ -48,7 +49,7 @@ const FilterDropmenuModalBackground = styled.div`
     right: 0;
     width: 100%;
     height: 100%;
-    background-color: transparent;
+    background-color: ${color.issue_drop_modal_bg};
     z-index: 1000;
 `;
 

--- a/frontend/src/components/IssueFilterMenu/IssueFilterMenuPresenter/IssueFilterMenuPresenter.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterMenuPresenter/IssueFilterMenuPresenter.jsx
@@ -1,0 +1,89 @@
+import React, { useContext } from "react";
+import styled from "styled-components";
+import { Checkbox, Caret } from "@components";
+import IssueFilterMenuContext from "../IssueFilterMenuContext/IssueFilterMenuContext";
+import IssueFilterDropmenu from "../IssueFilterDropmenu/IssueFilterDropmenu";
+
+const IssueFilterMenuArea = styled.div`
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+`;
+
+const IssueFileterMenuList = styled.ul`
+    display: flex;
+`;
+
+const IssueFilterItem = styled.li`
+    margin-right: 16px;
+    &:last-of-type {
+        margin: 0;
+    }
+`;
+
+const IssueDropButton = styled.button`
+    position: relative;
+    & > span {
+        margin-right: 5px;
+        color: #6a737d;
+    }
+    &:hover > span {
+        color: #444d56;
+    }
+`;
+
+const IssueFileterDropButton = ({ children, ...rest }) => {
+    return (
+        <IssueDropButton type="button" {...rest}>
+            <span>{children}</span>
+            <Caret />
+        </IssueDropButton>
+    );
+};
+
+const FilterDropmenuModalBackground = styled.div`
+    display: ${(props) => (props.isHidden ? "none" : "block")};
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    background-color: transparent;
+    z-index: 1000;
+`;
+
+const FilterDropmenuArea = styled.div`
+    position: absolute;
+    display: ${(props) => (props.isHidden ? "none" : "block")};
+    z-index: 2000;
+`;
+
+const IssueFilterMenuPresenter = () => {
+    const { issueFilterMenuState, eventListeners } = useContext(IssueFilterMenuContext);
+
+    const getIssueFilterMenus = () =>
+        issueFilterMenuState.issueFilterMenus.reduce(
+            (acc, cur) =>
+                acc.concat(
+                    <IssueFilterItem key={cur.id}>
+                        <IssueFileterDropButton data-id={cur.id} onClick={eventListeners.onFilterDromButtonClickListener}>
+                            {cur.title}
+                        </IssueFileterDropButton>
+                        <FilterDropmenuModalBackground isHidden={cur.isHiddenDropmenu} onClick={eventListeners.onModalBackgrondClickListener} />
+                        <FilterDropmenuArea isHidden={cur.isHiddenDropmenu}>
+                            <IssueFilterDropmenu filterType={cur.title} title={cur.title} />
+                        </FilterDropmenuArea>
+                    </IssueFilterItem>
+                ),
+            []
+        );
+
+    return (
+        <IssueFilterMenuArea>
+            <Checkbox type="checkbox" />
+            <IssueFileterMenuList>{getIssueFilterMenus()}</IssueFileterMenuList>
+        </IssueFilterMenuArea>
+    );
+};
+
+export default IssueFilterMenuPresenter;

--- a/frontend/src/components/IssueIcon/IssueIcon.jsx
+++ b/frontend/src/components/IssueIcon/IssueIcon.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import issueOpenIcon from "@imgs/issue-open-icon.png";
+import issueClosedIcon from "@imgs/issue-closed-icon.png";
+import styled from "styled-components";
+
+const IssueIconImg = styled.img`
+    width: 16px;
+    height: 16px;
+`;
+
+const IssueIcon = ({ ...rest }) => {
+    const { open, close } = rest;
+
+    return <IssueIconImg {...rest} src={open ? issueOpenIcon : issueClosedIcon} alt="이슈아이콘" />;
+};
+
+export default IssueIcon;

--- a/frontend/src/components/IssueItem/IssueItem.jsx
+++ b/frontend/src/components/IssueItem/IssueItem.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 import { Checkbox, IssueIcon, Label, UserProfile } from "@components";
 import milestoneIcon from "@imgs/milestone-gray-icon.png";
 
@@ -34,12 +35,12 @@ const IssueTitle = styled.span`
     font-weight: 600;
     cursor: pointer;
     &:hover {
-        color: #0366d6;
+        color: ${color.issue_item_title};
     }
 `;
 
 const IssueDetailInfo = styled.span`
-    color: #6a737d;
+    color: ${color.issue_item_detail_info_text};
 `;
 
 const IssueMilestoneTagArea = styled.div`
@@ -54,7 +55,7 @@ const IssueMilestoneImg = styled.img`
 `;
 
 const IssueMilestoneTitle = styled.span`
-    color: #6a737d;
+    color: ${color.issue_item_milestone_title};
 `;
 
 const IssueMilestoneTag = ({ children }) => {

--- a/frontend/src/components/IssueItem/IssueItem.jsx
+++ b/frontend/src/components/IssueItem/IssueItem.jsx
@@ -1,0 +1,169 @@
+import React from "react";
+import styled from "styled-components";
+import { Checkbox, IssueIcon, Label, UserProfile } from "@components";
+import milestoneIcon from "@imgs/milestone-gray-icon.png";
+
+const IssueItemArea = styled.div`
+    display: flex;
+    align-items: flex-start;
+    & > input {
+        margin-right: 17px;
+    }
+`;
+
+const IssueItemInfoArea = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+`;
+
+const IssueItemInfo = styled.div`
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+    &:last-of-type {
+        margin: 0;
+    }
+    & > * {
+        margin-right: 5px;
+    }
+`;
+
+const IssueTitle = styled.span`
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    &:hover {
+        color: #0366d6;
+    }
+`;
+
+const IssueDetailInfo = styled.span`
+    color: #6a737d;
+`;
+
+const IssueMilestoneTagArea = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const IssueMilestoneImg = styled.img`
+    width: 16px;
+    height: 16px;
+    margin-right: 5px;
+`;
+
+const IssueMilestoneTitle = styled.span`
+    color: #6a737d;
+`;
+
+const IssueMilestoneTag = ({ children }) => {
+    return (
+        <IssueMilestoneTagArea>
+            <IssueMilestoneImg src={milestoneIcon} />
+            <IssueMilestoneTitle>{children}</IssueMilestoneTitle>
+        </IssueMilestoneTagArea>
+    );
+};
+
+const IssueLabelList = styled.ul`
+    display: flex;
+    & > li {
+        margin-right: 5px;
+    }
+`;
+
+const IssueAssigneeList = styled.ul`
+    position: relative;
+    ${(props) =>
+        Array(props.totalAssignees)
+            .fill(0)
+            .reduce(
+                (acc, cur, idx) =>
+                    (acc += `&:hover > li:nth-child(${idx + 1}) {
+                        transform: translateX(${-20 * idx}px);
+            }`),
+                ""
+            )}
+`;
+
+const AssigneeListItem = styled.li`
+    position: absolute;
+    right: 0;
+    transition: transform 0.1s ease-in;
+    transform: translateX(${(props) => props.idx * -8}px);
+    z-index: ${(props) => props.totalAssignees - props.idx};
+    cursor: pointer;
+`;
+
+const IssueItem = ({ id, title, labels, milestone, assignees, author, createdAt }) => {
+    const getLabels = () =>
+        labels.reduce(
+            (acc, cur) =>
+                acc.concat(
+                    <li key={cur.id}>
+                        <Label color={cur.color}>{cur.name}</Label>
+                    </li>
+                ),
+            []
+        );
+
+    const getAssignees = () =>
+        assignees.reduce(
+            (acc, cur, idx, arr) =>
+                acc.concat(
+                    <AssigneeListItem key={cur.id} idx={idx} totalAssignees={arr.length}>
+                        <UserProfile imageUrl={cur.profileImage} />
+                    </AssigneeListItem>
+                ),
+            []
+        );
+
+    const getIssueDetailInfo = () => {
+        const getCreationTime = () => {
+            const nowDate = new Date(new Date().toUTCString());
+            const createDate = new Date(createdAt);
+
+            const elapsedMSec = nowDate - createDate;
+            if (elapsedMSec < 1000) return "now";
+
+            const elapsedSec = elapsedMSec / 1000;
+            if (elapsedSec < 60) return `${Math.floor(elapsedSec)} seconds ago`;
+
+            const elapsedMin = elapsedSec / 60;
+            if (elapsedMin < 60) return `${Math.floor(elapsedMin)} minute ago`;
+
+            const elapsedHour = elapsedMin / 60;
+            if (elapsedHour < 24) return `${Math.floor(elapsedHour)} hours ago`;
+
+            const elapsedDay = elapsedHour / 24;
+            if (elapsedDay < 30) return `${Math.floor(elapsedDay)} days ago`;
+
+            const removePattern = /\s[0-9:]+ [GMT+0-9]+ [ㄱ-ㅎ가-힣(\s)]+/;
+            return `${createDate.toString().replace(removePattern, "")}`;
+        };
+        return `#${id} opened ${getCreationTime()} by ${author.name}`;
+    };
+
+    return (
+        <IssueItemArea>
+            <Checkbox />
+            <IssueItemInfoArea>
+                <div>
+                    <IssueItemInfo>
+                        <IssueIcon open />
+                        <IssueTitle>{title}</IssueTitle>
+                        <IssueLabelList>{getLabels()}</IssueLabelList>
+                    </IssueItemInfo>
+                    <IssueItemInfo>
+                        <IssueDetailInfo>{getIssueDetailInfo()}</IssueDetailInfo>
+                        <IssueMilestoneTag>{milestone.title}</IssueMilestoneTag>
+                    </IssueItemInfo>
+                </div>
+                <IssueAssigneeList totalAssignees={assignees.length}>{getAssignees()}</IssueAssigneeList>
+            </IssueItemInfoArea>
+        </IssueItemArea>
+    );
+};
+
+export default IssueItem;

--- a/frontend/src/components/ListGroup/ListGroupArea.jsx
+++ b/frontend/src/components/ListGroup/ListGroupArea.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import styled from "styled-components";
+
+const ListGroupSection = styled.section`
+    width: 100%;
+    max-width: 1280px;
+    margin-top 50px;
+`;
+
+const ListGroupArea = ({ children, ...rest }) => {
+    return <ListGroupSection {...rest}>{children}</ListGroupSection>;
+};
+
+export default ListGroupArea;

--- a/frontend/src/components/ListGroup/ListGroupArea.jsx
+++ b/frontend/src/components/ListGroup/ListGroupArea.jsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 const ListGroupSection = styled.section`
     width: 100%;
     max-width: 1280px;
-    margin-top 50px;
 `;
 
 const ListGroupArea = ({ children, ...rest }) => {

--- a/frontend/src/components/ListGroup/ListGroupHeader.jsx
+++ b/frontend/src/components/ListGroup/ListGroupHeader.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 
 const ListGroupHeaderArea = styled.div`
     display: flex;
@@ -8,7 +9,7 @@ const ListGroupHeaderArea = styled.div`
     border: 1px solid #eaecef;
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
-    background-color: #f6f8fa;
+    background-color: ${color.list_group_header_bg};
     & > input {
         margin-right: 17px;
     }

--- a/frontend/src/components/ListGroup/ListGroupHeader.jsx
+++ b/frontend/src/components/ListGroup/ListGroupHeader.jsx
@@ -6,7 +6,7 @@ const ListGroupHeaderArea = styled.div`
     display: flex;
     align-items: center;
     padding: 23px;
-    border: 1px solid #eaecef;
+    border: 1px solid ${color.list_group_header_border};
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
     background-color: ${color.list_group_header_bg};

--- a/frontend/src/components/ListGroup/ListGroupHeader.jsx
+++ b/frontend/src/components/ListGroup/ListGroupHeader.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+
+const ListGroupHeaderArea = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 23px;
+    border: 1px solid #eaecef;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    background-color: #f6f8fa;
+    & > input {
+        margin-right: 17px;
+    }
+`;
+
+const ListGroupHeader = ({ children, ...rest }) => {
+    return <ListGroupHeaderArea {...rest}>{children}</ListGroupHeaderArea>;
+};
+
+export default ListGroupHeader;

--- a/frontend/src/components/ListGroup/ListGroupItem.jsx
+++ b/frontend/src/components/ListGroup/ListGroupItem.jsx
@@ -1,18 +1,19 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 
 const ListGroupItemLi = styled.li`
     padding: 23px;
     border-left: 1px solid #eaecef;
     border-right: 1px solid #eaecef;
     border-bottom: 1px solid #eaecef;
-    background-color: #ffffff;
+    background-color: ${color.list_group_item_bg};
     &:last-of-type {
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;
     }
     &:hover {
-        background-color: #f6f8fa;
+        background-color: ${color.list_group_item_hover_bg};
     }
 `;
 

--- a/frontend/src/components/ListGroup/ListGroupItem.jsx
+++ b/frontend/src/components/ListGroup/ListGroupItem.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import styled from "styled-components";
+
+const ListGroupItemLi = styled.li`
+    padding: 23px;
+    border-left: 1px solid #eaecef;
+    border-right: 1px solid #eaecef;
+    border-bottom: 1px solid #eaecef;
+    &:last-of-type {
+        border-bottom-left-radius: 6px;
+        border-bottom-right-radius: 6px;
+    }
+`;
+
+const ListGroupItem = ({ children, ...rest }) => {
+    return <ListGroupItemLi {...rest}>{children}</ListGroupItemLi>;
+};
+
+export default ListGroupItem;

--- a/frontend/src/components/ListGroup/ListGroupItem.jsx
+++ b/frontend/src/components/ListGroup/ListGroupItem.jsx
@@ -6,9 +6,13 @@ const ListGroupItemLi = styled.li`
     border-left: 1px solid #eaecef;
     border-right: 1px solid #eaecef;
     border-bottom: 1px solid #eaecef;
+    background-color: #ffffff;
     &:last-of-type {
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;
+    }
+    &:hover {
+        background-color: #f6f8fa;
     }
 `;
 

--- a/frontend/src/components/ListGroup/ListGroupItemList.jsx
+++ b/frontend/src/components/ListGroup/ListGroupItemList.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "styled-components";
+
+const ListGroupItemUl = styled.ul`
+    height: 100%;
+    max-height: ${(props) => (props.isEmpty ? "328px" : "none")};
+    border-right: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
+    border-left: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
+    border-bottom: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+`;
+
+const ListGroupItemList = ({ children, ...rest }) => {
+    return (
+        <ListGroupItemUl {...rest} isEmpty={!children}>
+            {children}
+        </ListGroupItemUl>
+    );
+};
+
+export default ListGroupItemList;

--- a/frontend/src/components/ListGroup/ListGroupItemList.jsx
+++ b/frontend/src/components/ListGroup/ListGroupItemList.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "@style/color";
 
 const ListGroupItemUl = styled.ul`
     height: 100%;
     max-height: ${(props) => (props.isEmpty ? "328px" : "none")};
-    border-right: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
-    border-left: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
-    border-bottom: ${(props) => (props.isEmpty ? "1px solid #eaecef" : "none")};
+    border-right: ${(props) => (props.isEmpty ? `1px solid ${color.list_group_border}` : "none")};
+    border-left: ${(props) => (props.isEmpty ? `1px solid ${color.list_group_border}` : "none")};
+    border-bottom: ${(props) => (props.isEmpty ? `1px solid ${color.list_group_border}` : "none")};
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
 `;

--- a/frontend/src/components/ListGroup/index.js
+++ b/frontend/src/components/ListGroup/index.js
@@ -1,0 +1,4 @@
+export { default as Area } from "./ListGroupArea";
+export { default as Header } from "./ListGroupHeader";
+export { default as Item } from "./ListGroupItem";
+export { default as ItemList } from "./ListGroupItemList";

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -6,3 +6,7 @@ export { default as Header } from "./Header/HeaderContainer/HeaderContainer";
 export { default as UserProfile } from "./UserProfile/UserProfile";
 export { default as Caret } from "./Caret/Caret";
 export * as ListGroup from "./ListGroup";
+export { default as Checkbox } from "./Checkbox/Checkbox";
+export { default as IssueIcon } from "./IssueIcon/IssueIcon";
+export { default as IssueItem } from "./IssueItem/IssueItem";
+export { default as IssueFilterMenu } from "./IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer";

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -5,3 +5,4 @@ export { default as Label } from "./Label/Label";
 export { default as Header } from "./Header/HeaderContainer/HeaderContainer";
 export { default as UserProfile } from "./UserProfile/UserProfile";
 export { default as Caret } from "./Caret/Caret";
+export * as ListGroup from "./ListGroup";

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -5,11 +5,10 @@ import { usePromise } from "@hook";
 import axios from "axios";
 import { UserContext } from "@context";
 import Config from "@config";
-import { Header } from "@components";
+import { Header, ListGroup, IssueItem, IssueFilterMenu } from "@components";
 
 const Main = styled.main`
     height: 100%;
-    background-color: beige;
 `;
 
 const waitAuthorizationApi = async () => {
@@ -24,11 +23,104 @@ const MainPage = () => {
     if (error) return <Redirect to="/login" />;
     if (!resolved) return null;
 
+    const issues = [
+        {
+            id: 1,
+            title: "로그인 기능 구현",
+            labels: [
+                {
+                    id: 1,
+                    name: "back-end",
+                    color: "#85f97a"
+                },
+                {
+                    id: 2,
+                    name: "modify",
+                    color: "#4f8ec1"
+                }
+            ],
+            milestone: {
+                id: 1,
+                title: "Back-end"
+            },
+            assignees: [
+                {
+                    id: 1,
+                    name: "crong",
+                    profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+                }
+            ],
+            author: {
+                id: 1,
+                name: "jinhyukoo"
+            },
+            createdAt: "2020-10-09T08:11:57.136Z"
+        },
+        {
+            id: 2,
+            title: "로그인 폼 컴포넌트 제작",
+            labels: [
+                {
+                    id: 3,
+                    name: "front-end",
+                    color: "#ed6d71"
+                }
+            ],
+            milestone: {
+                id: 2,
+                title: "Front-end"
+            },
+            assignees: [
+                {
+                    id: 1,
+                    name: "crong",
+                    profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+                },
+                {
+                    id: 2,
+                    name: "crong2",
+                    profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+                },
+                {
+                    id: 3,
+                    name: "crong2",
+                    profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+                },
+                {
+                    id: 4,
+                    name: "crong2",
+                    profileImage: "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg"
+                }
+            ],
+            author: {
+                id: 2,
+                name: "wooojini"
+            },
+            createdAt: "2020-11-09T18:01:34.136Z"
+        }
+    ];
+
+    const getIssueItems = () =>
+        issues.reduce(
+            (acc, cur) =>
+                acc.concat(
+                    <ListGroup.Item key={cur.id}>
+                        <IssueItem {...cur} />
+                    </ListGroup.Item>
+                ),
+            []
+        );
+
     return (
         <UserContext.Provider value={resolved.data}>
             <Header />
             <Main>
-                <h1>메인페이지입니다</h1>
+                <ListGroup.Area>
+                    <ListGroup.Header>
+                        <IssueFilterMenu />
+                    </ListGroup.Header>
+                    <ListGroup.ItemList>{getIssueItems()}</ListGroup.ItemList>
+                </ListGroup.Area>
             </Main>
         </UserContext.Provider>
     );


### PR DESCRIPTION
## 📕 제목

ListGroup 컴포넌트 제작 및 IssueItem 컴포넌트 제작
관련이슈 #16 #18 #19 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/32856129/98701984-36cb0d00-23bd-11eb-8e07-9a629e89aa96.gif)


- [x] ListGroup 컴포넌트를 여러페이지에서 재사용 가능하도록 제작
- [x] IssueItem 컴포넌트 제작
- [x] 이슈목록 필터 컴포넌트 제작
- [x] 구현도중 재사용 가능해보이는 체크박스 컴포넌트 제작


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ListGroup은 재사용 가능하도록 전체 구조를 분리한 컴포넌트로 분리되어 있습니다.
  - header, itemList, item 컴포넌트를 활용하여 적절히 구성할 수 있도록 제작하였습니다.
  - 제작과정에서 컴포넌트 이름이 길어지고, 전체 구조를 부분적으로 나누다보니 네이밍을 효율적으로 하기위해 아래 사용예시와 같이 컴포넌트를 참조하도록 제작하였습니다. => [React Bootstrap](https://react-bootstrap.github.io/components/list-group/)의 컴포넌트 방식을 참조하였습니다. 
  - 사용예시
```
<UserContext.Provider value={resolved.data}>
            <Header />
            <Main>
                <ListGroup.Area>
                    <ListGroup.Header>
                         //....헤더에 끼울 컴포넌트
                    </ListGroup.Header>
                    <ListGroup.ItemList>
                        <ListGroup.Item>....</<ListGroup.Item>
                        <ListGroup.Item>....</<ListGroup.Item>
                         //....리스트로 넣을 컴포넌트
                    </ListGroup.ItemList>
                </ListGroup.Area>
            </Main>
  </UserContext.Provider>
```
- 이슈 목록에 들어갈 이슈 내용을 담을 컴포넌를 제작하면서 ListGroup은 다른 페이지에서 범용적으로 사용될 수 있는 기존의 ListGroupItem 보다는 IssueItem이 적절해보여 해당 이름으로 변경하여 제작하였습니다.
- 이슈 목록 페이지 헤더에 들어갈 필터 메뉴들은 구조가 복잡해지는 것을 느껴 container와 presenter로 나누고, context와 reducer를 조합하여 제작하였습니다.
- 이슈 목록 페이지에서 체크박스의 동작은 메인 페이지에서 구현이 들어가야한다고 판단하여 별도의 issue를 만들고 구현해얄 할 것 같아 구현하지 않았습니다.