### PR TITLE
refactor: [FE] 로그인/회원가입 폼 공통컴포넌트 분리

### DIFF
--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -16,7 +16,8 @@ const color = {
     tab_selected_bg: "#ffffff",
     tab_container_gb: "#ffffff",
     border_primary: "#e1e4e8",
-    register_btn: "#2e9afe",
+    register_btn: "rgb(46, 154, 254)",
+    register_btn_disabled: "rgba(46, 154, 254, 0.5)",
     loading_dots: "#d8d8d8",
     sidemenu_hover: "#2e9afe",
     sidemenu_default: "#6e6e6e",
@@ -47,8 +48,7 @@ const color = {
     list_group_header_bg: "#f6f8fa",
     list_group_item_bg: "#ffffff",
     list_group_item_hover_bg: "#f6f8fa",
-    list_group_border: "#eaecef",
-    main_bg: "#ffffff"
+    list_group_border: "#eaecef"
 };
 
 export { color };

--- a/frontend/src/components/Form/FormContainer.jsx
+++ b/frontend/src/components/Form/FormContainer.jsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { color } from "@style/color";
+
+const StyledFormContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    place-items: center;
+    background-color: ${color.signup_container};
+    width: 30%;
+    height: 40%;
+    border-radius: 0.2rem;
+    border: 0.1rem; solid ${color.signup_box_border};
+`;
+
+export default StyledFormContainer;

--- a/frontend/src/components/Form/FormInput.jsx
+++ b/frontend/src/components/Form/FormInput.jsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+import { color } from "@style/color";
+
+const StyledFormInput = styled.input`
+    width: 70%;
+    border-radius: 0.2rem;
+    border: 0.1rem solid ${color.signup_box_border};
+    padding: 0.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    box-sizing: border-box;
+`;
+
+export default StyledFormInput;

--- a/frontend/src/components/Form/FormLabel.jsx
+++ b/frontend/src/components/Form/FormLabel.jsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const StyledFormLabel = styled.label`
+    margin-right: auto;
+    margin-left: 15%;
+    font-weight: bold;
+`;
+
+export default StyledFormLabel;

--- a/frontend/src/components/Form/FormSubmit.jsx
+++ b/frontend/src/components/Form/FormSubmit.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import { color } from "@style/color";
+
+const StyledSubmitButton = styled.button`
+    width: 70%;
+    border-radius: 0.2rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    border: 0.1rem solid ${color.signup_box_border};
+    color: ${color.signup_submit_text};
+    font-weight: bold;
+    box-sizing: border-box;
+    background-color: ${(props) => (props.disabled ? color.signup_submit_disabled : color.signup_submit)};
+`;
+
+export default StyledSubmitButton;

--- a/frontend/src/components/Form/WarningMessage.jsx
+++ b/frontend/src/components/Form/WarningMessage.jsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import { color } from "@style/color";
+
+const WarningMessage = styled.div`
+    display: none;
+    color: ${color.form_warning_msg};
+    font-size: 0.3rem;
+    margin-right: auto;
+    margin-left: 15%;
+    margin-bottom: 0.5rem;
+`;
+
+export default WarningMessage;

--- a/frontend/src/components/Form/index.js
+++ b/frontend/src/components/Form/index.js
@@ -1,0 +1,5 @@
+export { default as Container } from "./FormContainer";
+export { default as Input } from "./FormInput";
+export { default as Label } from "./FormLabel";
+export { default as Submit } from "./FormSubmit";
+export { default as WarningMessage } from "./WarningMessage";

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -16,6 +16,7 @@ const RegisterButton = styled.button`
     border: none;
     background-color: none;
     color: ${color.register_btn};
+    color: ${(props) => (props.disabled ? color.register_btn_disabled : color.register_btn)};
     font-weight: bold;
     margin-left: auto;
     margin-right: auto;

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -1,60 +1,9 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import styled from "styled-components";
 import { debounce } from "lodash";
 import config from "@config";
 import { color } from "@style/color";
-
-const LoginFormContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    place-items: center;
-    background-color: white;
-    width: 30%;
-    height: 40%;
-    border-radius: 0.2rem;
-    border: 0.1rem; solid #E6E6E6;
-`;
-const LoginFormLabel = styled.label`
-    margin-right: auto;
-    margin-left: 15%;
-    font-weight: bold;
-`;
-const LoginFormInput = styled.input`
-    width: 70%;
-    border-radius: 0.2rem;
-    border: 0.1rem solid #e6e6e6;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    box-sizing: border-box;
-`;
-
-const GitHubLoginButton = styled.button`
-    width: 70%;
-    border-radius: 0.2rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    border: 0.1rem solid #e6e6e6;
-    background-color: #a4a4a4;
-    color: white;
-    font-weight: bold;
-    box-sizing: border-box;
-`;
-
-const WarningMessage = styled.div`
-    display: none;
-    color: red;
-    font-size: 0.3rem;
-    margin-right: auto;
-    margin-left: 15%;
-    margin-bottom: 0.5rem;
-`;
+import { Form } from "@components";
 
 const RegisterButtonContainer = styled.div`
     width: 70%;
@@ -72,40 +21,58 @@ const RegisterButton = styled.button`
     margin-right: auto;
 `;
 
-const handlingClick = () => {
+const GitHubLoginClick = () => {
     window.location.href = config.API.GET_GITHUB_LOGIN;
+};
+
+const SubmitClick = () => {
+    alert("이벤트 발생");
 };
 
 const LoginForm = () => {
     const idWarning = useRef();
     const passwordWarning = useRef();
+    const submitButton = useRef();
+    const [idInputFilled, setIdInputFilled] = useState(false);
+    const [passwordInputFilled, setPasswordInputFilled] = useState(false);
 
     const inputOnChange = (event) => {
         const inputLength = event.target.value.length;
         const targetDOM = event.target.id === "user-input" ? idWarning.current : passwordWarning.current;
-        const maxLength = event.target.id === "user-input" ? 16 : 12;
+        const maxLength = event.target.id === "user-input" ? 26 : 12;
+        const targetState = event.target.id === "user-input" ? setIdInputFilled : setPasswordInputFilled;
         if ((inputLength > 0 && inputLength < 6) || inputLength > maxLength) {
             targetDOM.style.display = "block";
+            targetState(false);
+        } else if (inputLength === 0) {
+            targetDOM.style.display = "none";
+            targetState(false);
         } else {
             targetDOM.style.display = "none";
+            targetState(true);
         }
     };
+
     const debouncedInputOnChange = debounce(inputOnChange, 500);
 
     return (
-        <LoginFormContainer>
-            <LoginFormLabel htmlFor="user-input"> 아이디 </LoginFormLabel>
-            <LoginFormInput type="text" name="username" id="user-input" onChange={debouncedInputOnChange} />
-            <WarningMessage ref={idWarning}>아이디는 6~16자 사이로 입력해주세요.</WarningMessage>
-            <LoginFormLabel htmlFor="user-input"> 비밀번호 </LoginFormLabel>
-            <LoginFormInput type="password" name="username" id="password-input" onChange={debouncedInputOnChange} />
-            <WarningMessage ref={passwordWarning}>비밀번호는 6~12자 사이로 입력해주세요.</WarningMessage>
+        <Form.Container>
+            <Form.Label htmlFor="user-input"> 이메일 </Form.Label>
+            <Form.Input type="text" id="user-input" onChange={debouncedInputOnChange} />
+            <Form.WarningMessage ref={idWarning}>이메일은 6~26자 사이로 입력해주세요.</Form.WarningMessage>
+            <Form.Label htmlFor="password-input"> 비밀번호 </Form.Label>
+            <Form.Input type="password" id="password-input" onChange={debouncedInputOnChange} />
+            <Form.WarningMessage ref={passwordWarning}> 비밀번호는 6~12자 사이로 입력해주세요.</Form.WarningMessage>
             <RegisterButtonContainer>
-                <RegisterButton>로그인</RegisterButton>
+                <RegisterButton onClick={SubmitClick} disabled={!(idInputFilled && passwordInputFilled)}>
+                    로그인
+                </RegisterButton>
                 <RegisterButton>회원가입</RegisterButton>
             </RegisterButtonContainer>
-            <GitHubLoginButton onClick={handlingClick}>Sign in with GitHub</GitHubLoginButton>
-        </LoginFormContainer>
+            <Form.Submit ref={submitButton} onClick={GitHubLoginClick}>
+                Sign in with GitHub
+            </Form.Submit>
+        </Form.Container>
     );
 };
 

--- a/frontend/src/components/SignupForm/SignupForm.jsx
+++ b/frontend/src/components/SignupForm/SignupForm.jsx
@@ -1,56 +1,6 @@
 import React, { useRef, useState } from "react";
-import styled from "styled-components";
 import { debounce } from "lodash";
-import { color } from "@style/color";
-
-const SignupFormContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    place-items: center;
-    background-color: ${color.signup_container};
-    width: 30%;
-    height: 40%;
-    border-radius: 0.2rem;
-    border: 0.1rem; solid ${color.signup_box_border};
-`;
-const SignupFormLabel = styled.label`
-    margin-right: auto;
-    margin-left: 15%;
-    font-weight: bold;
-`;
-const SignupFormInput = styled.input`
-    width: 70%;
-    border-radius: 0.2rem;
-    border: 0.1rem solid ${color.signup_box_border};
-    padding: 0.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    box-sizing: border-box;
-`;
-
-const SignupSubmitButton = styled.button`
-    width: 70%;
-    border-radius: 0.2rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    border: 0.1rem solid ${color.signup_box_border};
-    color: ${color.signup_submit_text};
-    font-weight: bold;
-    box-sizing: border-box;
-    background-color: ${(props) => (props.disabled ? color.signup_submit_disabled : color.signup_submit)};
-`;
-
-const WarningMessage = styled.div`
-    display: none;
-    color: ${color.form_warning_msg};
-    font-size: 0.3rem;
-    margin-right: auto;
-    margin-left: 15%;
-    margin-bottom: 0.5rem;
-`;
+import { Form } from "@components";
 
 const SubmitClick = () => {
     alert("이벤트 발생");
@@ -83,19 +33,19 @@ const SignupForm = () => {
     const debouncedInputOnChange = debounce(inputOnChange, 500);
 
     return (
-        <SignupFormContainer>
-            <SignupFormLabel htmlFor="user-input"> 이름 </SignupFormLabel>
-            <SignupFormInput type="text" id="user-input" />
-            <SignupFormLabel htmlFor="user-input"> 이메일 </SignupFormLabel>
-            <SignupFormInput type="text" id="user-input" onChange={debouncedInputOnChange} />
-            <WarningMessage ref={idWarning}>이메일은 6~26자 사이로 입력해주세요.</WarningMessage>
-            <SignupFormLabel htmlFor="user-input"> 비밀번호 </SignupFormLabel>
-            <SignupFormInput type="password" id="password-input" onChange={debouncedInputOnChange} />
-            <WarningMessage ref={passwordWarning}>비밀번호는 6~12자 사이로 입력해주세요.</WarningMessage>
-            <SignupSubmitButton ref={submitButton} onClick={SubmitClick} disabled={!(idInputFilled && passwordInputFilled)}>
+        <Form.Container>
+            <Form.Label htmlFor="name-input"> 이름 </Form.Label>
+            <Form.Input type="text" id="name-input" />
+            <Form.Label htmlFor="user-input"> 이메일 </Form.Label>
+            <Form.Input type="text" id="user-input" onChange={debouncedInputOnChange} />
+            <Form.WarningMessage ref={idWarning}>이메일은 6~26자 사이로 입력해주세요.</Form.WarningMessage>
+            <Form.Label htmlFor="password-input"> 비밀번호 </Form.Label>
+            <Form.Input type="password" id="password-input" onChange={debouncedInputOnChange} />
+            <Form.WarningMessage ref={passwordWarning}> 비밀번호는 6~12자 사이로 입력해주세요.</Form.WarningMessage>
+            <Form.Submit ref={submitButton} onClick={SubmitClick} disabled={!(idInputFilled && passwordInputFilled)}>
                 가입하기
-            </SignupSubmitButton>
-        </SignupFormContainer>
+            </Form.Submit>
+        </Form.Container>
     );
 };
 

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -14,3 +14,4 @@ export { default as IssueItem } from "./IssueItem/IssueItem";
 export { default as IssueFilterMenu } from "./IssueFilterMenu/IssueFilterMenuContainer/IssueFilterMenuContainer";
 export { default as Main } from "./Main/Main";
 export { default as ProgressBar } from "./ProgressBar/ProgressBar";
+export * as Form from "./Form";

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -2,18 +2,8 @@ import React from "react";
 import { Redirect } from "react-router-dom";
 import { usePromise } from "@hook";
 import { UserContext } from "@context";
-import Config from "@config";
-import { Header, Main ListGroup, IssueItem, IssueFilterMenu } from "@components";
+import { Header, Main, ListGroup, IssueItem, IssueFilterMenu } from "@components";
 import { waitAuthorizationApi } from "@utils";
-        
-const Main = styled.main`
-    height: 100%;
-`;
-
-const waitAuthorizationApi = async () => {
-    const userInfo = await axios.get(Config.API.GET_AUTH, { withCredentials: true });
-    return userInfo;
-};
 
 const MainPage = () => {
     const [loading, resolved, error] = usePromise(waitAuthorizationApi, []);


### PR DESCRIPTION
## 📕 제목

#106 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [ ] 공통 컴포넌트 분리
  - 컨테이너
  - 입력창
  - 라벨
  - 제출버튼
  - 경고메세지
- [ ] 컴포넌트 활용하여 페이지 재구성


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Debounce를 활용하여 입력창을 검사하는 함수 역시 중복되지만 시간문제상 일단 컴포넌트만 분리시켰습니다. 시간이 난다면 이 부분도 리팩토링 시도해보겠습니다.
- 사진을 올리지 않았는데 기존 로그인/회원가입 화면과 똑같습니다. 단 로그인 화면에는 조건을 만족시키지 않으면 로그인 버튼이 disabled되는 로직을 추가시켰습니다.