### PR TITLE
모든 User, Author, Assignee 조회 API 구현

### DIFF
--- a/backend/src/common/type/index.js
+++ b/backend/src/common/type/index.js
@@ -1,2 +1,3 @@
 export { default as ISSUESTATE } from "./issue-state";
 export { default as MILESTONESTATE } from "./milestone-state";
+export { default as USER_TYPE } from "./user-type";

--- a/backend/src/common/type/user-type.js
+++ b/backend/src/common/type/user-type.js
@@ -1,0 +1,6 @@
+const USER_TYPE = {
+    AUTHUOR: "author",
+    ASSIGNEE: "assignee"
+};
+
+export default USER_TYPE;

--- a/backend/src/controller/user-controller.js
+++ b/backend/src/controller/user-controller.js
@@ -1,3 +1,5 @@
+import { UserService } from "../service";
+
 const sendUserInfo = (req, res, next) => {
     const { user } = req;
     res.status(200).send({
@@ -7,4 +9,15 @@ const sendUserInfo = (req, res, next) => {
     });
 };
 
-export { sendUserInfo };
+const sendUsers = async (req, res, next) => {
+    try {
+        const userService = UserService.getInstance();
+        const users = await userService.getUsers();
+
+        res.status(200).json(users);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export { sendUserInfo, sendUsers };

--- a/backend/src/controller/user-controller.js
+++ b/backend/src/controller/user-controller.js
@@ -1,4 +1,5 @@
 import { UserService } from "../service";
+import { USER_TYPE } from "../common/type";
 
 const sendUserInfo = (req, res, next) => {
     const { user } = req;
@@ -11,10 +12,23 @@ const sendUserInfo = (req, res, next) => {
 
 const sendUsers = async (req, res, next) => {
     try {
+        const { type } = req.query;
         const userService = UserService.getInstance();
-        const users = await userService.getUsers();
 
-        res.status(200).json(users);
+        let users;
+        switch (type) {
+            case USER_TYPE.AUTHUOR:
+                users = await userService.getAuthors();
+                break;
+            case USER_TYPE.ASSIGNEE:
+                users = await userService.getAssignees();
+                break;
+            default:
+                users = await userService.getUsers();
+        }
+
+        const jsonData = users.reduce((acc, cur) => acc.concat({ id: cur.id, name: cur.name }), []);
+        res.status(200).json({ users: jsonData });
     } catch (error) {
         next(error);
     }

--- a/backend/src/dto/user.js
+++ b/backend/src/dto/user.js
@@ -1,0 +1,9 @@
+import { IsString, IsOptional } from "class-validator";
+
+class GetUserQuery {
+    @IsOptional()
+    @IsString()
+    type;
+}
+
+export { GetUserQuery };

--- a/backend/src/router/user.js
+++ b/backend/src/router/user.js
@@ -1,9 +1,13 @@
 import express from "express";
 import { userController } from "../controller";
+import { RequestType } from "../common/middleware/request-type";
+import { transformer } from "../common/middleware/transformer";
+import { validator } from "../common/middleware/validator";
+import { GetUserQuery } from "../dto/user";
 
 const router = express.Router();
 
-router.get("/", userController.sendUsers);
+router.get("/", transformer([RequestType.QUERY], [GetUserQuery]), validator([RequestType.QUERY]), userController.sendUsers);
 
 router.get("/info", userController.sendUserInfo);
 

--- a/backend/src/router/user.js
+++ b/backend/src/router/user.js
@@ -3,6 +3,8 @@ import { userController } from "../controller";
 
 const router = express.Router();
 
+router.get("/", userController.sendUsers);
+
 router.get("/info", userController.sendUserInfo);
 
 export default router;

--- a/backend/src/service/user-service.js
+++ b/backend/src/service/user-service.js
@@ -41,6 +41,11 @@ class UserService {
         return user === undefined;
     }
 
+    async getUsers() {
+        const users = await this.userRepository.find();
+        return users;
+    }
+
     async getUserByEmail(useremail) {
         const user = await this.userRepository.findOne({ email: useremail });
         return user;

--- a/backend/src/service/user-service.js
+++ b/backend/src/service/user-service.js
@@ -5,10 +5,12 @@ import { crypto } from "../common/lib";
 import { EntityAlreadyExist } from "../common/error/entity-already-exist";
 import { EntityNotFoundError } from "../common/error/entity-not-found-error";
 import { BadRequestError } from "../common/error/bad-request-error";
+import { UserToIssue } from "../model/user-to-issue";
 
 class UserService {
     constructor() {
         this.userRepository = getRepository(User);
+        this.userToIssueRepository = getRepository(UserToIssue);
         this.defaultProfileImage = "https://pbs.twimg.com/profile_images/977835673511084032/xXA979th.jpg";
     }
 
@@ -44,6 +46,19 @@ class UserService {
     async getUsers() {
         const users = await this.userRepository.find();
         return users;
+    }
+
+    async getAuthors() {
+        const authors = await this.userRepository.createQueryBuilder("user").innerJoinAndSelect("user.issues", "a").getMany();
+        return authors;
+    }
+
+    async getAssignees() {
+        const userToIssues = await this.userToIssueRepository
+            .createQueryBuilder("user_to_issue")
+            .innerJoinAndSelect("user_to_issue.user", "a")
+            .getMany();
+        return [...userToIssues].map((userToIssue) => userToIssue.user);
     }
 
     async getUserByEmail(useremail) {

--- a/backend/test/router/user.test.js
+++ b/backend/test/router/user.test.js
@@ -1,0 +1,152 @@
+import { getEntityManagerOrTransactionManager } from "typeorm-transactional-cls-hooked";
+import { agent } from "supertest";
+import { TransactionWrapper } from "../TransactionWrapper";
+import { ApplicationFactory } from "../../src/application-factory";
+import { generateJWTToken } from "../../src/common/lib/token-generator";
+import { IssueService } from "../../src/service/issue-service";
+
+const mockUsers = [
+    { id: 1, email: "newtest1@test.com", name: "테스터테스터1", password: "test123!@#", profileImage: "profile image" },
+    { id: 2, email: "newtest2@test.com", name: "테스터테스터2", password: "test123!@#", profileImage: "profile image" },
+    { id: 3, email: "newtest3@test.com", name: "테스터테스터3", password: "test123!@#", profileImage: "profile image" },
+    { id: 4, email: "newtest4@test.com", name: "테스터테스터4", password: "test123!@#", profileImage: "profile image" }
+];
+const mockIssues = [
+    { userId: 1, title: "issue title", content: "issue content" },
+    { userId: 2, title: "issue title2", content: "issue content2" }
+];
+
+describe("User Router Test", () => {
+    let app = null;
+
+    beforeAll(async () => {
+        app = await ApplicationFactory.create();
+    });
+
+    test("로그인한 사용자가 모든 유저 정보를 조회할 수 있다", async () => {
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            const promises = mockUsers.map(({ email, name, password }) =>
+                agent(app.httpServer).post(`/auth/signup`).send({
+                    email,
+                    name,
+                    password
+                })
+            );
+            await Promise.all(promises);
+
+            const token = generateJWTToken({
+                userId: mockUsers[0].id,
+                username: mockUsers[0].name,
+                email: mockUsers[0].email,
+                photos: mockUsers[0].profileImage
+            });
+
+            // when
+            const response = await agent(app.httpServer)
+                .get(`/api/user`)
+                .set("Cookie", [`token=${token}`])
+                .send();
+
+            // then
+            expect(response.status).toEqual(200);
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+
+    test("로그인한 모든 이슈 작성자(Author)를 조회할 수 있다", async () => {
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            const promises = mockUsers.map(({ email, name, password }) =>
+                agent(app.httpServer).post(`/auth/signup`).send({
+                    email,
+                    name,
+                    password
+                })
+            );
+            await Promise.all(promises);
+
+            const token = generateJWTToken({
+                userId: mockUsers[0].id,
+                username: mockUsers[0].name,
+                email: mockUsers[0].email,
+                photos: mockUsers[0].profileImage
+            });
+
+            await agent(app.httpServer)
+                .post(`/api/issue`)
+                .set("Cookie", [`token=${token}`])
+                .send({
+                    title: mockIssues[0].title,
+                    content: mockIssues[0].content
+                });
+
+            // when
+            const response = await agent(app.httpServer)
+                .get(`/api/user?type=author`)
+                .set("Cookie", [`token=${token}`])
+                .send();
+
+            // then
+            expect(200).toEqual(200);
+            expect(response.body.users[0].name).toBe(mockUsers[0].name);
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+
+    test("로그인한 모든 Assignee를 조회할 수 있다", async () => {
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            const promises = mockUsers.map(({ email, name, password }) =>
+                agent(app.httpServer).post(`/auth/signup`).send({
+                    email,
+                    name,
+                    password
+                })
+            );
+            await Promise.all(promises);
+
+            const token = generateJWTToken({
+                userId: mockUsers[0].id,
+                username: mockUsers[0].name,
+                email: mockUsers[0].email,
+                photos: mockUsers[0].profileImage
+            });
+
+            await agent(app.httpServer)
+                .post(`/api/issue`)
+                .set("Cookie", [`token=${token}`])
+                .send({
+                    title: mockIssues[0].title,
+                    content: mockIssues[0].content
+                });
+
+            await agent(app.httpServer)
+                .post(`/api/issue/1/assignee/1`)
+                .set("Cookie", [`token=${token}`])
+                .send();
+
+            // when
+            const response = await agent(app.httpServer)
+                .get(`/api/user?type=assignee`)
+                .set("Cookie", [`token=${token}`])
+                .send();
+
+            // then
+            expect(response.status).toEqual(200);
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+});

--- a/backend/test/service/user-service.test.js
+++ b/backend/test/service/user-service.test.js
@@ -6,8 +6,40 @@ import { LoginRequestBody } from "../../src/dto/auth";
 import { User } from "../../src/model/user";
 import { BadRequestError } from "../../src/common/error/bad-request-error";
 import { EntityNotFoundError } from "../../src/common/error/entity-not-found-error";
+import { IssueService } from "../../src/service/issue-service";
 
 const mockUser = { email: "test@test.com", name: "테스터", password: "test123!@#", profileImage: "profile image" };
+const mockUsers = [
+    {
+        email: "test1@test.com",
+        name: "테스터1",
+        password: "test123!@#"
+    },
+    {
+        email: "test2@test.com",
+        name: "테스터2",
+        password: "test123!@#"
+    },
+    {
+        email: "test3@test.com",
+        name: "테스터3",
+        password: "test123!@#"
+    },
+    {
+        email: "test4@test.com",
+        name: "테스터4",
+        password: "test123!@#"
+    }
+];
+const mockIssues = [
+    { userId: 1, title: "issue title", content: "issue content" },
+    { userId: 2, title: "issue title2", content: "issue content2" }
+];
+
+const mockIssuesAssignee = [
+    { assigneeId: 3, issueId: 1 },
+    { assigneeId: 4, issueId: 2 }
+];
 
 describe("UserService Test", () => {
     const app = new Application();
@@ -25,8 +57,7 @@ describe("UserService Test", () => {
             await entityManager.query("SAVEPOINT STARTPOINT");
 
             // given
-            const user = entityManager.create(User, mockUser);
-            await userService.signup(user);
+            await userService.signup({ email: mockUser.email, name: mockUser.name, password: mockUser.password });
 
             const loginRequestBody = new LoginRequestBody();
             loginRequestBody.email = mockUser.email;
@@ -36,10 +67,9 @@ describe("UserService Test", () => {
             const authenticatedUser = await userService.authenticate(loginRequestBody);
 
             // then
-            expect(authenticatedUser.id).toBe(user.id);
-            expect(authenticatedUser.name).toBe(user.name);
-            expect(authenticatedUser.password).toBe(user.password);
-            expect(authenticatedUser.profileImage).toBe(user.profileImage);
+            expect(authenticatedUser.id).toBe(1);
+            expect(authenticatedUser.name).toBe(mockUser.name);
+            expect(authenticatedUser.email).toBe(mockUser.email);
 
             await entityManager.query("ROLLBACK TO STARTPOINT");
         });
@@ -94,6 +124,89 @@ describe("UserService Test", () => {
                 // then
                 expect(error instanceof EntityNotFoundError);
             }
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+
+    test("모든 회원을 조회할 수 있다.", async () => {
+        const userService = UserService.getInstance();
+
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            const promises = mockUsers.map(({ email, name, password }) => userService.signup({ email, name, password }));
+            await Promise.all(promises);
+
+            // when
+            const users = await userService.getUsers();
+
+            // then
+            users.sort((user1, user2) => (user1.name > user2.name ? 1 : -1));
+            users.forEach((user, idx) => {
+                expect(user.email).toBe(mockUsers[idx].email);
+                expect(user.name).toBe(mockUsers[idx].name);
+            });
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+
+    test("Assignee로 배정된 모든 회원을 조회할 수 있다", async () => {
+        const userService = UserService.getInstance();
+        const issueService = IssueService.getInstance();
+
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            let promises = mockUsers.map(({ email, name, password }) => userService.signup({ email, name, password }));
+            await Promise.all(promises);
+
+            promises = mockIssues.map(({ userId, title, content }) => issueService.addIssue({ userId, title, content }));
+            await Promise.all(promises);
+
+            promises = mockIssuesAssignee.map(({ assigneeId, issueId }) => issueService.addAssignee(assigneeId, issueId));
+            await Promise.all(promises);
+
+            // when
+            const assignees = await userService.getAssignees();
+
+            // then
+            assignees.forEach((assignee, idx) => {
+                expect(assignee.id).toBe(mockIssuesAssignee[idx].assigneeId);
+                expect(assignee.id).toBe(mockIssuesAssignee[idx].assigneeId);
+            });
+
+            await entityManager.query("ROLLBACK TO STARTPOINT");
+        });
+    });
+
+    test("글을 작성한 모든 회원을 조회할 수 있다", async () => {
+        const userService = UserService.getInstance();
+        const issueService = IssueService.getInstance();
+
+        await TransactionWrapper.transaction(async () => {
+            const entityManager = getEntityManagerOrTransactionManager();
+            await entityManager.query("SAVEPOINT STARTPOINT");
+
+            // given
+            let promises = mockUsers.map(({ email, name, password }) => userService.signup({ email, name, password }));
+            await Promise.all(promises);
+
+            promises = mockIssues.map(({ userId, title, content }) => issueService.addIssue({ userId, title, content }));
+            await Promise.all(promises);
+
+            // when
+            const authors = await userService.getAuthors();
+
+            // then
+            authors.forEach((author, idx) => {
+                expect(author.id).toBe(mockIssues[idx].userId);
+            });
 
             await entityManager.query("ROLLBACK TO STARTPOINT");
         });


### PR DESCRIPTION
## 📕 제목

모든 User, Author, Assignee 조회 API 구현
#32 


## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 모든 User 조회 테스트 코드 작성
- [x] 모든 Author 조회 테스트 코드 작성
- [x] 모든 Assignee 조회 및 테스트 코드 작성
- [x] GET 요청시 위 3가지 경우에 따라 조회할 수 있도록 API 수정
  - 쿼리스트링으로 type을 설정하여 조회
  - /api/user
  - /api/user?type=author
  - /api/user?type=assignee


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- API를 구현하면서 User, Author, Assignee를 조회할 수 있도록 쿼리스트링이 추가되었습니다.