### PR TITLE
feat: [FE] 이슈 생성 페이지 UI 구현

### DIFF
--- a/frontend/src/common/style/color.js
+++ b/frontend/src/common/style/color.js
@@ -48,7 +48,10 @@ const color = {
     list_group_item_bg: "#ffffff",
     list_group_item_hover_bg: "#f6f8fa",
     list_group_border: "#eaecef",
-    main_bg: "#ffffff"
+    container_border: "#e1e4e8",
+    title_input_bg: "#fafbfc",
+    title_input_border: "#e1e4e8",
+    title_input_focus_border: "#0366d6"
 };
 
 export { color };

--- a/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderDropmenu/HeaderDropmenu.jsx
@@ -118,7 +118,7 @@ const HeaderDropmenu = () => {
     return (
         <DropmenuContainer>
             <DropmenuButton type="button" onClick={eventListeners.onDropmenuClickListner}>
-                <UserProfile imageUrl={headerState.userProfileImage} />
+                <UserProfile imageUrl={headerState.userProfileImage} width="20px" height="20px" />
                 <Caret primary />
             </DropmenuButton>
             <DropmenuModalBackground isHidden={headerState.isHiddenDropmenu} onClick={eventListeners.onModalBackgrondClickListener} />

--- a/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
+++ b/frontend/src/components/IssueFilterMenu/IssueFilterDropmenu/IssueFilterDropmenu.jsx
@@ -35,7 +35,7 @@ const ProfileItem = ({ id, name, profileImage }) => {
     return (
         <IssueFilterDropmenuItem>
             <ProfileItemArea>
-                <UserProfile imageUrl={profileImage} />
+                <UserProfile imageUrl={profileImage} width="20px" height="20px" />
                 <span>{name}</span>
             </ProfileItemArea>
         </IssueFilterDropmenuItem>

--- a/frontend/src/components/IssueItem/IssueItem.jsx
+++ b/frontend/src/components/IssueItem/IssueItem.jsx
@@ -114,7 +114,7 @@ const IssueItem = ({ id, title, labels, milestone, assignees, author, createdAt 
             (acc, cur, idx, arr) =>
                 acc.concat(
                     <AssigneeListItem key={cur.id} idx={idx} totalAssignees={arr.length}>
-                        <UserProfile imageUrl={cur.profileImage} />
+                        <UserProfile imageUrl={cur.profileImage} width="20px" height="20px" />
                     </AssigneeListItem>
                 ),
             []

--- a/frontend/src/components/SidebarMenu/SidebarMenu.jsx
+++ b/frontend/src/components/SidebarMenu/SidebarMenu.jsx
@@ -9,7 +9,6 @@ const StyledSideBarMenu = styled.div`
     border-bottom: 0.1px solid ${color.sidemenu_default};
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
-    margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     box-sizing: border-box;
     width: 15rem;
@@ -18,7 +17,6 @@ const StyledSideBarMenu = styled.div`
 const StyledSideBarMenuHeader = styled.div`
     display: flex;
     justify-content: space-between;
-    margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     line-height: 1.5;
     font-weight: bold;
@@ -35,7 +33,6 @@ const StyledSideBarMenuHeader = styled.div`
 const StyledSideBarMenuBody = styled.div`
     display: flex;
     flex-direction: column;
-    margin-top: 0.5rem;
     margin-bottom: 0.5rem;
 `;
 

--- a/frontend/src/components/UserProfile/UserProfile.jsx
+++ b/frontend/src/components/UserProfile/UserProfile.jsx
@@ -2,16 +2,16 @@ import React from "react";
 import styled from "styled-components";
 
 const StyledImg = styled.img`
-    width: 20px;
-    height: 20px;
+    width: ${(props) => props.width};
+    height: ${(props) => props.height};
     overflow: hidden;
     line-height: 1;
     vertical-align: middle;
     border-radius: 50% !important;
 `;
 
-const UserProfile = ({ imageUrl }) => {
-    return <StyledImg src={imageUrl} />;
+const UserProfile = ({ imageUrl, width, height }) => {
+    return <StyledImg src={imageUrl} width={width} height={height} />;
 };
 
 export default UserProfile;

--- a/frontend/src/pages/NewIssuePage.jsx
+++ b/frontend/src/pages/NewIssuePage.jsx
@@ -1,14 +1,83 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Redirect } from "react-router-dom";
 import { usePromise } from "@hook";
 import { UserContext } from "@context";
-import { Header, Main } from "@components";
+import { Header, Main, ContentEditor, SidebarMenu, Button, UserProfile } from "@components";
 import { waitAuthorizationApi } from "@utils";
+import { LoadingPage } from "@pages";
+import styled from "styled-components";
+import { color } from "@style/color";
+
+const StyledNewIssueContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: space-between;
+`;
+
+const StyledLeftContainer = styled.div`
+    margin-top: 3rem;
+`;
+
+const CenterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 3rem;
+    margin-left: 1rem;
+    margin-right: 1rem;
+    border: 1px solid ${color.container_border};
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+`;
+
+const CenterButtonContainer = styled.div`
+    width: 95%;
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 0.5rem;
+`;
+
+const RightContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 3rem;
+`;
+
+const TitleInput = styled.input`
+    width: 95%;
+    line-height: 2;
+    margin-bottom: 1rem;
+    background-color: ${color.title_input_bg};
+    border: 1px solid ${color.title_input_border};
+    border-radius: 7px;
+    padding-left: 0.5rem;
+    &:focus {
+        background-color: ${color.main_bg};
+        border: 1px solid ${color.title_input_focus_border};
+        outline: none;
+        box-shadow: inset 0 1px 2px rgba(27, 31, 35, 0.075), 0 0 0 3px rgba(3, 102, 214, 0.3);
+    }
+`;
+
+const LeftContainer = () => {
+    const { photoImage } = useContext(UserContext);
+    return (
+        <StyledLeftContainer>
+            <UserProfile imageUrl={photoImage} width="40px" height="40px" />
+        </StyledLeftContainer>
+    );
+};
 
 const NewIssuePage = () => {
     const [loading, resolved, error] = usePromise(waitAuthorizationApi, []);
 
-    if (loading) return <div>로딩중..!</div>;
+    if (loading)
+        return (
+            <div>
+                <LoadingPage />
+            </div>
+        );
     if (error) return <Redirect to="/login" />;
     if (!resolved) return null;
 
@@ -16,7 +85,22 @@ const NewIssuePage = () => {
         <UserContext.Provider value={resolved.data}>
             <Header />
             <Main>
-                <p>이슈 생성페이지입니다</p>
+                <StyledNewIssueContainer>
+                    <LeftContainer />
+                    <CenterContainer>
+                        <TitleInput placeholder="Title" />
+                        <ContentEditor />
+                        <CenterButtonContainer>
+                            <Button>Cancle</Button>
+                            <Button primary>Submit new issue</Button>
+                        </CenterButtonContainer>
+                    </CenterContainer>
+                    <RightContainer>
+                        <SidebarMenu title="Assignees" />
+                        <SidebarMenu title="Labels" />
+                        <SidebarMenu title="Milestone" />
+                    </RightContainer>
+                </StyledNewIssueContainer>
             </Main>
         </UserContext.Provider>
     );


### PR DESCRIPTION
## 📕 제목

#111 
![image](https://user-images.githubusercontent.com/46101366/98853292-41a89f00-249c-11eb-92fb-268081a1d58d.png)

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [ ] 프로필 사진 배치
- [ ] 에디터 컴포넌트 배치
- [ ] 사이드바 메뉴 컴포넌트 배치
- [ ] 레이아웃 작업

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 이슈 생성 페이지 외에도 몇 개 수정된 점이 있습니다. 확인해두시면 좋을 것 같아요.
- UserProfile에 props로 width와 height가 추가되었습니다. 다른건 몰라도 이건 알아두셔야 합니다!