### PR TITLE
reset.scss 변경으로 인한 컴포넌트 리스트 스타일 변경 

### DIFF
--- a/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
+++ b/frontend/src/components/Header/HeaderPresenter/HeaderPresenter.jsx
@@ -11,6 +11,13 @@ const HeaderArea = styled.header`
     padding: 15px 30px;
     background-color: ${color.header_bg};
     box-sizing: border-box;
+    & ul {
+        margin: 0;
+        padding: 0;
+        li {
+            list-style: none;
+        }
+    }
 `;
 
 const HeaderContent = styled.div`

--- a/frontend/src/components/ListGroup/ListGroupArea.jsx
+++ b/frontend/src/components/ListGroup/ListGroupArea.jsx
@@ -4,6 +4,13 @@ import styled from "styled-components";
 const ListGroupSection = styled.section`
     width: 100%;
     max-width: 1280px;
+    & ul {
+        margin: 0;
+        padding: 0;
+        li {
+            list-style: none;
+        }
+    }
 `;
 
 const ListGroupArea = ({ children, ...rest }) => {


### PR DESCRIPTION
## 📕 제목

reset.scss 변경으로 인한 컴포넌트 리스트 스타일 변경 


## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 헤더, 이슈 아이템 컴포넌트 리스트 스타일 수정



## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 리스트 스타일 수정 반영했습니다 :-)