### PR TITLE
feat: [BE] 이슈 세부 조회 API 응답 수정

### DIFF
--- a/backend/src/controller/issue-controller.js
+++ b/backend/src/controller/issue-controller.js
@@ -1,3 +1,4 @@
+import { ISSUESTATE } from "../common/type";
 import { IssueService } from "../service/issue-service";
 
 const addIssue = async (req, res, next) => {
@@ -110,7 +111,9 @@ const getIssueById = async (req, res, next) => {
             labels,
             milestone: {
                 id: issue?.milestone?.id,
-                title: issue?.milestone?.title
+                title: issue?.milestone?.title,
+                openIssueCount: issue?.milestone?.issues?.filter((i) => i.state === ISSUESTATE.OPEN)?.length,
+                closedIssueCount: issue?.milestone?.issues?.filter((i) => i.state === ISSUESTATE.CLOSED)?.length
             },
             assignees,
             comments

--- a/backend/src/service/issue-service.js
+++ b/backend/src/service/issue-service.js
@@ -233,6 +233,7 @@ class IssueService {
             .leftJoinAndSelect("issue.labelToIssues", "b")
             .leftJoinAndSelect("b.label", "b_0")
             .leftJoinAndSelect("issue.milestone", "c")
+            .leftJoinAndSelect("c.issues", "c_0")
             .leftJoinAndSelect("issue.userToIssues", "d")
             .leftJoinAndSelect("d.user", "d_0")
             .leftJoinAndSelect("issue.comments", "e", "e.deleted_at IS NULL")


### PR DESCRIPTION
## 📕 제목

이슈 세부 조회 API의 응답을 수정했습니다.
```
{
    "issue": {
        "id": 1,
        "title": "issue title",
        "content": "issue content",
        "state": "open",
        "createdAt": "2020-11-12T15:58:25.000Z",
        "updatedAt": "2020-11-12T15:58:25.000Z",
        "author": {
            "id": 1,
            "name": "youngxpepp1"
        },
        "labels": [],
        "milestone": {
            "id": 1,
            "title": "title",
            "openIssueCount": 2,
            "closedIssueCount": 1
        }
    }
}
```

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [ ] 이슈와 관련된 마일스톤의 진행 상황을 알 수 있게끔 openIssueCount와 closedIssueCount를 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 테스트가 없습니다ㅠㅠ 
